### PR TITLE
ワークフローの通知を別ステップに切り出す

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,7 +21,7 @@ jobs:
       steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3.1.1
         with:
           java-version: ${{ matrix.java-version }}
       - name: Grant execute permission for gradlew

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -29,6 +29,8 @@ jobs:
         run: chmod +x gradlew
       - name: Build with Gradle
         run: ./gradlew clean build --stacktrace
+      - name: status report
+        run: echo "This job's status is ${{ job.status }}."
 
     notification:
       needs: [ test ]

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,7 +16,7 @@ jobs:
 
       strategy:
         matrix:
-          java-version: [ 11, 12, 13, 14, 15, 16, 17, 18 ]
+          java-version: [ 11, 15, 16, 17, 18 ]
 
       steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -21,7 +21,7 @@ jobs:
       steps:
       - uses: actions/checkout@v2
       - name: Set up JDK
-        uses: actions/setup-java@v3.1.1
+        uses: actions/setup-java@v3.4.0
         with:
           java-version: ${{ matrix.java-version }}
           distribution: 'corretto'

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -10,11 +10,10 @@ on:
     branches: [ '**' ]
 
 jobs:
-  build:
-
-    runs-on: ubuntu-latest
 
     test:
+      runs-on: ubuntu-latest
+
       strategy:
         matrix:
           java-version: [ 11, 12, 13, 14, 15, 16, 17, 18 ]
@@ -31,7 +30,7 @@ jobs:
         run: ./gradlew clean build --stacktrace
 
     notification:
-      needs: [test]
+      needs: [ test ]
       steps:
       - name: Notify job finish
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -24,6 +24,7 @@ jobs:
         uses: actions/setup-java@v3.1.1
         with:
           java-version: ${{ matrix.java-version }}
+          distribution: 'corretto'
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Build with Gradle

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,6 +31,9 @@ jobs:
 
     notification:
       needs: [ test ]
+
+      runs-on: ubuntu-latest
+
       steps:
       - name: Notify job finish
         uses: 8398a7/action-slack@v3

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -16,7 +16,7 @@ jobs:
 
       strategy:
         matrix:
-          java-version: [ 11, 15, 16, 17, 18 ]
+          java-version: [ 11, 15, 16, 17 ]
 
       steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -14,26 +14,30 @@ jobs:
 
     runs-on: ubuntu-latest
 
-    strategy:
-      matrix:
-        java-version: [ 11, 12, 13, 14, 15, 16, 17 ]
+    test:
+      strategy:
+        matrix:
+          java-version: [ 11, 12, 13, 14, 15, 16, 17, 18 ]
 
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK
-      uses: actions/setup-java@v1
-      with:
-        java-version: ${{ matrix.java-version }}
-    - name: Grant execute permission for gradlew
-      run: chmod +x gradlew
-    - name: Build with Gradle
-      run: ./gradlew clean build --stacktrace
-    - name: Notify job finish
-      uses: 8398a7/action-slack@v3
-      with:
-        status: ${{ job.status }}
-        author_name: Build結果
-        fields: ref,job
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
-      if: always()
+      steps:
+      - uses: actions/checkout@v2
+      - name: Set up JDK
+        uses: actions/setup-java@v1
+        with:
+          java-version: ${{ matrix.java-version }}
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build with Gradle
+        run: ./gradlew clean build --stacktrace
+
+    notification:
+      steps:
+      - name: Notify job finish
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          author_name: Build結果
+          fields: ref,job
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -31,6 +31,7 @@ jobs:
         run: ./gradlew clean build --stacktrace
 
     notification:
+      needs: [test]
       steps:
       - name: Notify job finish
         uses: 8398a7/action-slack@v3


### PR DESCRIPTION
テストと通知が同じステップになっていたため通知だけ別ステップに切り出す。java複数バージョンのテストごとに通知が発生していたのを、最後に1回だけ通知されるように修正。