### PR TITLE
sheetタグ直下に複数タグ存在する時の不具合対応

### DIFF
--- a/src/main/java/io/luchta/forma4j/reader/compile/parse/tagbuilder/ListBuilder.java
+++ b/src/main/java/io/luchta/forma4j/reader/compile/parse/tagbuilder/ListBuilder.java
@@ -4,6 +4,7 @@ import io.luchta.forma4j.context.syntax.SyntaxErrors;
 import io.luchta.forma4j.reader.model.tag.ListTag;
 import io.luchta.forma4j.reader.model.tag.Tag;
 import io.luchta.forma4j.reader.model.tag.property.Index;
+import io.luchta.forma4j.reader.model.tag.property.Name;
 import org.w3c.dom.NamedNodeMap;
 import org.w3c.dom.Node;
 
@@ -55,13 +56,20 @@ public class ListBuilder implements TagBuilder {
             }
         }
 
-        Node nameNode = nodeMap.getNamedItem("");
+        Node nameNode = nodeMap.getNamedItem("name");
+        String name = "";
+        if (nameNode != null) {
+            name = nameNode.getNodeValue();
+        } else {
+            name = "list";
+        }
 
         return new ListTag(
                 new Index(headerStartRow),
                 new Index(headerStartCol),
                 new Index(detailStartRow),
-                new Index(detailStartCol)
+                new Index(detailStartCol),
+                new Name(name)
         );
     }
 }

--- a/src/main/java/io/luchta/forma4j/reader/excel/ExcelReader.java
+++ b/src/main/java/io/luchta/forma4j/reader/excel/ExcelReader.java
@@ -1,16 +1,17 @@
 package io.luchta.forma4j.reader.excel;
 
 import io.luchta.forma4j.context.databind.json.JsonNode;
+import io.luchta.forma4j.context.databind.json.JsonNodes;
 import io.luchta.forma4j.context.databind.json.JsonObject;
 import io.luchta.forma4j.reader.excel.objectreader.ObjectReader;
 import io.luchta.forma4j.reader.excel.objectreader.ObjectReaderFactory;
 import io.luchta.forma4j.reader.excel.objectreader.ObjectReaderFactoryParameter;
 import io.luchta.forma4j.reader.model.excel.Index;
-import io.luchta.forma4j.reader.specification.DefaultTagTreeSpec;
 import io.luchta.forma4j.reader.model.tag.SheetTag;
 import io.luchta.forma4j.reader.model.tag.Tag;
 import io.luchta.forma4j.reader.model.tag.TagTree;
 import io.luchta.forma4j.reader.model.tag.TagTrees;
+import io.luchta.forma4j.reader.specification.DefaultTagTreeSpec;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
@@ -52,21 +53,22 @@ public class ExcelReader {
     }
 
     private JsonObject read(Sheet sheet, TagTrees tagTrees) {
-
-        JsonObject obj = null;
-
         ObjectReaderFactory factory = new ObjectReaderFactory();
         Index rowIndex = new Index(0);
         Index colIndex = new Index(0);
+        JsonNodes nodes = new JsonNodes();
         for (TagTree tree : tagTrees) {
             Tag tag = tree.getTag();
             ObjectReaderFactoryParameter param = new ObjectReaderFactoryParameter(
                     sheet, rowIndex, colIndex, tree, tag
             );
             ObjectReader reader = factory.create(param);
-            obj = reader.read();
+            nodes.add(reader.read());
         }
 
-        return obj;
+        if (nodes.size() > 1) {
+            return new JsonObject(nodes);
+        }
+        return new JsonObject(nodes.get(0));
     }
 }

--- a/src/main/java/io/luchta/forma4j/reader/excel/objectreader/CellReader.java
+++ b/src/main/java/io/luchta/forma4j/reader/excel/objectreader/CellReader.java
@@ -27,7 +27,7 @@ public class CellReader implements ObjectReader {
     }
 
     @Override
-    public JsonObject read() {
+    public JsonNode read() {
 
         CellTag cellTag = (CellTag) tagTree.getTag();
 
@@ -38,7 +38,7 @@ public class CellReader implements ObjectReader {
         if (r == null) {
             JsonNode node = new JsonNode();
             node.putVar(cellTag.name().toString(), new JsonObject(""));
-            return new JsonObject(node);
+            return node;
         }
         Cell cell = sheet.getRow(row).getCell(col);
 
@@ -48,16 +48,16 @@ public class CellReader implements ObjectReader {
                 Instant instant = date.toInstant();
                 JsonNode node = new JsonNode();
                 node.putVar(cellTag.name().toString(), new JsonObject(LocalDateTime.ofInstant(instant, ZoneId.systemDefault())));
-                return new JsonObject(node);
+                return node;
             } else {
                 JsonNode node = new JsonNode();
                 node.putVar(cellTag.name().toString(), new JsonObject(cell.getNumericCellValue()));
-                return new JsonObject(node);
+                return node;
             }
         }
 
         JsonNode node = new JsonNode();
         node.putVar(cellTag.name().toString(), new JsonObject(cell.toString()));
-        return new JsonObject(node);
+        return node;
     }
 }

--- a/src/main/java/io/luchta/forma4j/reader/excel/objectreader/HForReader.java
+++ b/src/main/java/io/luchta/forma4j/reader/excel/objectreader/HForReader.java
@@ -22,7 +22,7 @@ public class HForReader implements ObjectReader {
     }
 
     @Override
-    public JsonObject read() {
+    public JsonNode read() {
 
         HForTag hForTag = (HForTag) tagTree.getTag();
 
@@ -57,8 +57,7 @@ public class HForReader implements ObjectReader {
                         sheet, rowIndex, new Index(i), child, tag
                 );
                 ObjectReader reader = factory.create(param);
-                JsonObject obj = reader.read();
-                JsonNode node = (JsonNode) obj.getValue();
+                JsonNode node = reader.read();
                 for (Map.Entry<String, JsonObject> entry : node.entrySet()) {
                     resultNode.putVar(entry.getKey() + (i - fromCol + 1), entry.getValue());
                 }
@@ -73,6 +72,6 @@ public class HForReader implements ObjectReader {
 
         JsonNode node = new JsonNode();
         node.putVar(hForTag.name().toString(), new JsonObject(resultNode));
-        return new JsonObject(node);
+        return node;
     }
 }

--- a/src/main/java/io/luchta/forma4j/reader/excel/objectreader/ListReader.java
+++ b/src/main/java/io/luchta/forma4j/reader/excel/objectreader/ListReader.java
@@ -24,7 +24,7 @@ public class ListReader implements ObjectReader {
     }
 
     @Override
-    public JsonObject read() {
+    public JsonNode read() {
         ListTag listTag = (ListTag) tagTree.getTag();
 
         Integer headerStartRowNum = listTag.getHeaderStartRow().toInteger();
@@ -68,6 +68,9 @@ public class ListReader implements ObjectReader {
             nodeList.add(node);
             j++;
         }
-        return new JsonObject(new JsonNodes(nodeList));
+        JsonObject jsonObject = new JsonObject(new JsonNodes(nodeList));
+        JsonNode node = new JsonNode();
+        node.putVar(listTag.name().toString(), jsonObject);
+        return node;
     }
 }

--- a/src/main/java/io/luchta/forma4j/reader/excel/objectreader/ObjectReader.java
+++ b/src/main/java/io/luchta/forma4j/reader/excel/objectreader/ObjectReader.java
@@ -1,7 +1,7 @@
 package io.luchta.forma4j.reader.excel.objectreader;
 
-import io.luchta.forma4j.context.databind.json.JsonObject;
+import io.luchta.forma4j.context.databind.json.JsonNode;
 
 public interface ObjectReader {
-    JsonObject read();
+    JsonNode read();
 }

--- a/src/main/java/io/luchta/forma4j/reader/excel/objectreader/VForReader.java
+++ b/src/main/java/io/luchta/forma4j/reader/excel/objectreader/VForReader.java
@@ -29,7 +29,7 @@ public class VForReader implements ObjectReader {
     }
 
     @Override
-    public JsonObject read() {
+    public JsonNode read() {
 
         VForTag vForTag = (VForTag) tagTree.getTag();
 
@@ -49,8 +49,7 @@ public class VForReader implements ObjectReader {
                         sheet, new Index(i), colIndex, child, tag
                 );
                 ObjectReader reader = factory.create(param);
-                JsonObject obj = reader.read();
-                JsonNode node = (JsonNode) obj.getValue();
+                JsonNode node = reader.read();
                 for (Map.Entry<String, JsonObject> entry : node.entrySet()) {
                     childrenNode.putVar(entry.getKey(), entry.getValue());
                 }
@@ -69,6 +68,6 @@ public class VForReader implements ObjectReader {
         JsonNode node = new JsonNode();
         node.putVar(vForTag.name().toString(), new JsonObject(new JsonNodes(nodeList)));
 
-        return new JsonObject(node);
+        return node;
     }
 }

--- a/src/main/java/io/luchta/forma4j/reader/model/tag/ListTag.java
+++ b/src/main/java/io/luchta/forma4j/reader/model/tag/ListTag.java
@@ -1,18 +1,21 @@
 package io.luchta.forma4j.reader.model.tag;
 
 import io.luchta.forma4j.reader.model.tag.property.Index;
+import io.luchta.forma4j.reader.model.tag.property.Name;
 
 public class ListTag implements Tag {
     Index headerStartRow;
     Index headerStartCol;
     Index detailStartRow;
     Index detailStartCol;
+    Name name;
 
-    public ListTag(Index headerStartRow, Index headerStartCol, Index detailStartRow, Index detailStartCol) {
+    public ListTag(Index headerStartRow, Index headerStartCol, Index detailStartRow, Index detailStartCol, Name name) {
         this.headerStartRow = headerStartRow;
         this.headerStartCol = headerStartCol;
         this.detailStartRow = detailStartRow;
         this.detailStartCol = detailStartCol;
+        this.name = name;
     }
 
     public Index getHeaderStartRow() {
@@ -29,6 +32,10 @@ public class ListTag implements Tag {
 
     public Index getDetailStartCol() {
         return detailStartCol;
+    }
+
+    public Name name() {
+        return name;
     }
 
     @Override

--- a/src/main/java/io/luchta/forma4j/reader/specification/DefaultTagTreeSpec.java
+++ b/src/main/java/io/luchta/forma4j/reader/specification/DefaultTagTreeSpec.java
@@ -10,7 +10,7 @@ import java.util.List;
 public class DefaultTagTreeSpec {
     public TagTree create() {
         List<TagTree> listTagTreeList = new ArrayList<>();
-        TagTree listTagTree = new TagTree(new Tags(), new ListTag(new Index(0), new Index(0), new Index(1), new Index(0)), new TagTrees());
+        TagTree listTagTree = new TagTree(new Tags(), new ListTag(new Index(0), new Index(0), new Index(1), new Index(0), new Name("list")), new TagTrees());
         listTagTreeList.add(listTagTree);
 
         List<TagTree> sheetTagTreeList = new ArrayList<>();

--- a/src/test/java/io/luchta/forma4j/reader/FormaReaderTest.java
+++ b/src/test/java/io/luchta/forma4j/reader/FormaReaderTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.params.provider.CsvSource;
 
 import java.io.FileInputStream;
 import java.io.InputStream;
+import java.time.LocalDateTime;
 
 public class FormaReaderTest {
 
@@ -29,11 +30,15 @@ public class FormaReaderTest {
             Assertions.assertEquals(true, sheet.getValue() instanceof JsonNode);
 
             JsonObject cell = ((JsonNode) sheet.getValue()).getVar("data");
-            Assertions.assertEquals(true, cell.getValue() instanceof JsonNode);
+            Assertions.assertEquals(true, cell.getValue() instanceof JsonNodes);
 
-            JsonObject value = ((JsonNode) cell.getValue()).getVar("title");
-            Assertions.assertEquals(true, value.getValue() instanceof String);
-            Assertions.assertEquals("サンプル帳票", value.toString());
+            JsonNodes values = ((JsonNodes) cell.getValue());
+
+            Assertions.assertEquals(true, values.get(0).getVar("title").getValue() instanceof String);
+            Assertions.assertEquals("サンプル帳票", values.get(0).getVar("title").getValue().toString());
+
+            Assertions.assertEquals(true, values.get(1).getVar("outputdate").getValue() instanceof LocalDateTime);
+            Assertions.assertEquals(LocalDateTime.of(2020, 11, 6, 0, 0, 0), values.get(1).getVar("outputdate").getValue());
         }
     }
 
@@ -53,10 +58,16 @@ public class FormaReaderTest {
             JsonObject sheet = ((JsonNode) root).getVar("forma-reader");
             Assertions.assertEquals(true, sheet.getValue() instanceof JsonNode);
 
-            JsonObject cell = ((JsonNode) sheet.getValue()).getVar("data");
-            Assertions.assertEquals(true, cell.getValue() instanceof JsonNode);
+            JsonObject data = ((JsonNode) sheet.getValue()).getVar("data");
+            Assertions.assertEquals(true, data.getValue() instanceof JsonNodes);
 
-            JsonObject value = ((JsonNode) cell.getValue()).getVar("employee");
+            JsonNodes nodes = (JsonNodes) data.getValue();
+
+            JsonObject title = nodes.get(0).getVar("title");
+            Assertions.assertEquals(true, title.getValue() instanceof String);
+            Assertions.assertEquals("サンプル帳票", title.getValue().toString());
+
+            JsonObject value = nodes.get(1).getVar("employee");
             Assertions.assertEquals(true, value.getValue() instanceof JsonNodes);
             JsonNodes employeeNodes = (JsonNodes) value.getValue();
             Assertions.assertEquals(5, employeeNodes.size());
@@ -220,7 +231,10 @@ public class FormaReaderTest {
             JsonObject sheet = ((JsonNode) root).getVar("forma-reader");
             Assertions.assertEquals(true, sheet.getValue() instanceof JsonNode);
 
-            JsonObject list = ((JsonNode) sheet.getValue()).getVar("data");
+            JsonObject data = ((JsonNode) sheet.getValue()).getVar("data");
+            Assertions.assertEquals(true, data.getValue() instanceof JsonNode);
+
+            JsonObject list = ((JsonNode) data.getValue()).getVar("employeeList");
             Assertions.assertEquals(true, list.getValue() instanceof JsonNodes);
 
             JsonNodes nodes = (JsonNodes) list.getValue();
@@ -318,10 +332,13 @@ public class FormaReaderTest {
             JsonObject sheet = ((JsonNode) root).getVar("forma-reader");
             Assertions.assertEquals(true, sheet.getValue() instanceof JsonNode);
 
-            JsonObject list = ((JsonNode) sheet.getValue()).getVar("data");
-            Assertions.assertEquals(true, list.getValue() instanceof JsonNodes);
+            JsonObject data = ((JsonNode) sheet.getValue()).getVar("data");
+            Assertions.assertEquals(true, data.getValue() instanceof JsonNode);
 
-            JsonNodes nodes = (JsonNodes) list.getValue();
+            JsonNode list = (JsonNode) data.getValue();
+            Assertions.assertEquals(true, list.getVar("list").getValue() instanceof JsonNodes);
+
+            JsonNodes nodes = (JsonNodes) list.getVar("list").getValue();
             Assertions.assertEquals(5, nodes.size());
 
             JsonNode node1 = nodes.get(0);

--- a/src/test/resources/reader/simple_cell_read_test.xml
+++ b/src/test/resources/reader/simple_cell_read_test.xml
@@ -2,5 +2,6 @@
 <forma-reader>
   <sheet name="data">
     <cell row="1" col="1" name="title" />
+    <cell row="3" col="2" name="outputdate" />
   </sheet>
 </forma-reader>

--- a/src/test/resources/reader/simple_list_read_test.xml
+++ b/src/test/resources/reader/simple_list_read_test.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <forma-reader>
   <sheet name="data">
-    <list headerStartRow="4" headerStartCol="1" detailStartRow="5" detailStartCol="1"/>
+    <list headerStartRow="4" headerStartCol="1" detailStartRow="5" detailStartCol="1" name="employeeList" />
   </sheet>
 </forma-reader>


### PR DESCRIPTION
sheetタグ直下に複数タグ存在するとき、最後に読み込まれたタグのみ有効となる不具合の修正。