### PR TITLE
ognl を外す

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,9 +40,6 @@ dependencies {
     implementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.0"
     implementation "com.sun.xml.bind:jaxb-impl:4.0.0"
 
-    // https://mvnrepository.com/artifact/ognl/ognl
-    implementation 'ognl:ognl:3.3.3'
-
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.13.3'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.13.3'
 

--- a/src/main/java/io/luchta/forma4j/writer/engine/resolver/VariableResolver.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/resolver/VariableResolver.java
@@ -4,35 +4,13 @@ import io.luchta.forma4j.writer.Context;
 import io.luchta.forma4j.writer.engine.buffer.loop.LoopContext;
 import io.luchta.forma4j.writer.engine.model.cell.value.Text;
 import io.luchta.forma4j.writer.engine.model.cell.value.XlsxCellValue;
-import ognl.*;
 
-import java.lang.reflect.AccessibleObject;
-import java.lang.reflect.Member;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
 public class VariableResolver {
-    static final OgnlContext ognlContext = new OgnlContext(
-            new DefaultClassResolver(),
-            new DefaultTypeConverter(),
-            new AbstractMemberAccess() {
-                // TODO イマイチ仕組みを理解しきれていない。やりたいのはpublic以外のfieldにもアクセスさせたい、というだけ
-                // TODO mybatisの実装を参考に refs. https://github.com/mybatis/mybatis-3/issues/1258
-                @Override
-                public Object setup(Map context, Object target, Member member, String propertyName) {
-                    AccessibleObject accessible = (AccessibleObject) member;
-                    accessible.setAccessible(true);
-                    return Boolean.FALSE;
-                }
-
-                @Override
-                public boolean isAccessible(Map context, Object target, Member member, String propertyName) {
-                    return true;
-                }
-            }
-    );
 
     Context context;
     LoopContext loopContext;
@@ -64,33 +42,33 @@ public class VariableResolver {
     }
 
     private Object getValue(String key, Context context) {
-        // TODO かなりいい加減なので見直す
         Object value = context.getVar(key);
         if (value != null) return value;
         String first = key.split("\\.")[0];
         Object contextVar = context.getVar(first);
         if (contextVar == null) return null;
-        try {
-            String rewriteKey = key.replaceFirst(first, "");
-            return Ognl.getValue(rewriteKey, ognlContext, contextVar);
-        } catch (OgnlException e) {
-            e.printStackTrace();
+
+        String rewriteKey = key.replaceFirst(first + ".", "");
+
+        if (contextVar instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>) contextVar;
+            return map.get(rewriteKey);
         }
         return null;
     }
 
     private Object getValue(String key, LoopContext loopContext) {
-        // TODO かなりいい加減なので見直す
         Object value = loopContext.getItem(key);
         if (value != null) return value;
         String first = key.split("\\.")[0];
         Object loopContextVar = loopContext.getItem(first);
         if (loopContextVar == null) return null;
-        try {
-            String rewriteKey = key.replaceFirst(first + ".", "");
-            return Ognl.getValue(rewriteKey, ognlContext, loopContextVar);
-        } catch (OgnlException e) {
-            e.printStackTrace();
+
+        String rewriteKey = key.replaceFirst(first + ".", "");
+
+        if (loopContextVar instanceof Map) {
+            Map<?, ?> map = (Map<?, ?>) loopContextVar;
+            return map.get(rewriteKey);
         }
         return null;
     }


### PR DESCRIPTION
ognl を外して map へアクセスするプログラムに書き換えた。

ognl の代替として SpEL を検討していたが、日本語に弱く map のキー項目が日本語の時にパースされずにエラーとなるケースがあったため SpEL の導入は取りやめにした。XML ファイルに計算式を記述させる想定がないため単純に map にアクセスできれば問題ないはず。