### PR TITLE
Release/v1.2.2

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,4 +4,4 @@ updates:
   - package-ecosystem: "gradle"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.0"
     implementation "com.sun.xml.bind:jaxb-impl:4.0.1"
     
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.0'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.1'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.14.1'
 
     antlr "org.antlr:antlr4:4.11.1"

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation "com.sun.xml.bind:jaxb-impl:4.0.1"
     
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.0'
-    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.14.0'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.14.1'
 
     antlr "org.antlr:antlr4:4.11.1"
 


### PR DESCRIPTION
v1.2.2リリース
* dependabotのインターバルをweeklyからmonthlyに変更
* jackson-core 2.14.0 -> 2.14.1
* jackson-datatype-jsr310 2.14.0 -> 2.14.1