### PR TITLE
ライブラリの最新化

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@
 ### Gradle
 
 ```gradle
-implementation group: 'io.luchta', name: 'forma4j', version: '1.3.0'
+implementation group: 'io.luchta', name: 'forma4j', version: '1.3.1'
 ```
 
 [Maven Repository](https://mvnrepository.com/artifact/io.luchta/forma4j)

--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
     implementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.0"
     implementation "com.sun.xml.bind:jaxb-impl:4.0.2"
     
-    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.2'
+    implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.15.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.14.2'
 
     antlr "org.antlr:antlr4:4.12.0"

--- a/build.gradle
+++ b/build.gradle
@@ -45,7 +45,7 @@ dependencies {
 
     antlr "org.antlr:antlr4:4.12.0"
 
-    testImplementation(platform('org.junit:junit-bom:5.9.2'))
+    testImplementation(platform('org.junit:junit-bom:5.9.3'))
     testImplementation('org.junit.jupiter:junit-jupiter')
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -41,7 +41,7 @@ dependencies {
     implementation "com.sun.xml.bind:jaxb-impl:4.0.2"
     
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.15.0'
-    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.14.2'
+    implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.15.0'
 
     antlr "org.antlr:antlr4:4.12.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation group: 'org.apache.poi', name: 'poi-ooxml', version: '5.2.3'
 
     implementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.0"
-    implementation "com.sun.xml.bind:jaxb-impl:4.0.1"
+    implementation "com.sun.xml.bind:jaxb-impl:4.0.2"
     
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.2'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.14.2'

--- a/build.gradle
+++ b/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.14.2'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.14.2'
 
-    antlr "org.antlr:antlr4:4.11.1"
+    antlr "org.antlr:antlr4:4.12.0"
 
     testImplementation(platform('org.junit:junit-bom:5.9.2'))
     testImplementation('org.junit.jupiter:junit-jupiter')

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 }
 
 group = 'io.luchta'
-version = '1.3.0'
+version = '1.3.1'
 
 sourceCompatibility = compatibility
 targetCompatibility = compatibility


### PR DESCRIPTION
* com.sun.xml.bind:jaxb-impl from 4.0.1 to 4.0.2
* org.antlr:antlr4 from 4.11.1 to 4.12.0.
* com.fasterxml.jackson.core:jackson-core from 2.14.2 to 2.15.0.
* com.fasterxml.jackson.datatype:jackson-datatype-jsr310 from 2.14.2 to 2.15.0.
* org.junit:junit-bom from 5.9.2 to 5.9.3.