### PR TITLE
autoSizeColumn の処理見直し

### DIFF
--- a/docs/writer/sheet.md
+++ b/docs/writer/sheet.md
@@ -19,6 +19,7 @@ sheetタグは以下のタグを子要素として持つことができます。
 | name | シート名を設定します。item、collectionタグを使用している場合は無視されます。 |
 | item | collectionを使用する場合に指定します。子孫要素はこのプロパティで指定した変数でcollectionの要素にアクセスすることができます。 |
 | collection | データコレクションです。データ件数の数だけsheetが自動的に作成されます。 |
+| autoSizeColumn | 列幅の自動調整を行うかどうかを設定します。`true` を指定すると有効、`false` を指定すると無効になります。未指定時は新規ブック作成では有効、テンプレートへの書き込みでは無効です。 |
 
 ## シートの出力
 
@@ -45,6 +46,24 @@ sheetタグは以下のタグを子要素として持つことができます。
 ```
 
 ![Excel](image/writer-sheet-2.svg)
+
+## 列幅の自動調整
+
+sheetタグの `autoSizeColumn` プロパティで列幅の自動調整を制御できます。
+
+```xml
+<?xml version="1.0" encoding="utf-8"?>
+<forma>
+  <sheet name="Example" autoSizeColumn="false">
+    <cell rowIndex="0" columnIndex="0">abcdefghijklmnopqrstuvwxyz0123456789</cell>
+  </sheet>
+</forma>
+```
+
+`autoSizeColumn` を省略した場合の既定値は以下の通りです。
+
+- 新規ブック作成時: `true`
+- テンプレートへの書き込み時: `false`
 
 ## 書き込み定義が同一のシートを複数出力
 

--- a/src/main/java/io/luchta/forma4j/writer/definition/schema/attribute/sheet/AutoSizeColumn.java
+++ b/src/main/java/io/luchta/forma4j/writer/definition/schema/attribute/sheet/AutoSizeColumn.java
@@ -1,0 +1,23 @@
+package io.luchta.forma4j.writer.definition.schema.attribute.sheet;
+
+import jakarta.xml.bind.annotation.XmlValue;
+
+public class AutoSizeColumn {
+    @XmlValue
+    String value;
+
+    public AutoSizeColumn() {
+    }
+
+    public AutoSizeColumn(String value) {
+        this.value = value;
+    }
+
+    public String value() {
+        return value;
+    }
+
+    public boolean isEmpty() {
+        return value == null;
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/definition/schema/element/Sheet.java
+++ b/src/main/java/io/luchta/forma4j/writer/definition/schema/element/Sheet.java
@@ -6,6 +6,7 @@ import io.luchta.forma4j.writer.definition.schema.ElementType;
 import io.luchta.forma4j.writer.definition.schema.attribute.Name;
 import io.luchta.forma4j.writer.definition.schema.attribute.loop.Collection;
 import io.luchta.forma4j.writer.definition.schema.attribute.loop.Item;
+import io.luchta.forma4j.writer.definition.schema.attribute.sheet.AutoSizeColumn;
 import jakarta.xml.bind.annotation.XmlAttribute;
 import jakarta.xml.bind.annotation.XmlElement;
 import jakarta.xml.bind.annotation.XmlElements;
@@ -35,6 +36,8 @@ public class Sheet implements Element {
     Item item = new Item();
     @XmlAttribute
     Collection collection = new Collection();
+    @XmlAttribute
+    AutoSizeColumn autoSizeColumn = new AutoSizeColumn();
     @XmlElements({
             @XmlElement(name = Row.ELEMENT_NAME, type = Row.class),
             @XmlElement(name = Column.ELEMENT_NAME, type = Column.class),
@@ -87,6 +90,10 @@ public class Sheet implements Element {
      */
     public Collection collection() {
         return collection;
+    }
+
+    public AutoSizeColumn autoSizeColumn() {
+        return autoSizeColumn;
     }
 
     /**

--- a/src/main/java/io/luchta/forma4j/writer/engine/buffer/accumulater/BuildAccumulator.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/buffer/accumulater/BuildAccumulator.java
@@ -23,16 +23,24 @@ import io.luchta.forma4j.writer.engine.model.sheet.XlsxSheet;
 import io.luchta.forma4j.writer.engine.model.sheet.XlsxSheetList;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class BuildAccumulator {
     SheetNameList sheetNameList = new SheetNameList();
     RowPropertyMap rowPropertyMap = new RowPropertyMap();
     ColumnPropertyMap columnPropertyMap = new ColumnPropertyMap();
     CellMap cells = new CellMap();
+    Map<XlsxSheetName, Boolean> autoSizeColumnEnabledMap = new HashMap<>();
 
     public void add(XlsxSheetName sheetName) {
+        add(sheetName, null);
+    }
+
+    public void add(XlsxSheetName sheetName, Boolean autoSizeColumnEnabled) {
         sheetNameList.add(sheetName);
+        autoSizeColumnEnabledMap.put(sheetName, autoSizeColumnEnabled);
     }
 
     public void put(XlsxCellAddress address, XlsxCell cell) {
@@ -66,7 +74,12 @@ public class BuildAccumulator {
         List<XlsxSheet> sheetList = new ArrayList<>();
         for (XlsxSheetName sheetName : sheetNameList) {
             XlsxRowList rowList = toRowList(sheetName);
-            sheetList.add(new XlsxSheet(sheetName, rowList, columnPropertyMap.getBySheetName(sheetName)));
+            sheetList.add(new XlsxSheet(
+                    sheetName,
+                    rowList,
+                    columnPropertyMap.getBySheetName(sheetName),
+                    autoSizeColumnEnabledMap.get(sheetName)
+            ));
         }
         return new XlsxSheetList(sheetList);
     }

--- a/src/main/java/io/luchta/forma4j/writer/engine/handler/element/SheetHandler.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/handler/element/SheetHandler.java
@@ -41,10 +41,11 @@ public class SheetHandler {
      */
     public void handle(Sheet sheet) {
         Collection collection = sheet.collection();
+        Boolean autoSizeColumnEnabled = autoSizeColumnEnabled(sheet);
         if (collection.isEmpty()) {
             XlsxSheetName sheetName = new XlsxSheetName(sheet.name());
             XlsxCellAddress address = new XlsxCellAddress(sheetName, XlsxRowNumber.init(), XlsxColumnNumber.init());
-            buffer.accumulator().add(sheetName);
+            buffer.accumulator().add(sheetName, autoSizeColumnEnabled);
             buffer.addressStack().push(address);
             try {
                 dispatch(sheet.children());
@@ -73,7 +74,7 @@ public class SheetHandler {
                 Map<String, Object> map = (Map<String, Object>) obj;
                 XlsxSheetName sheetName = new XlsxSheetName(new Name(map.get("sheetName").toString()));
                 XlsxCellAddress address = new XlsxCellAddress(sheetName, XlsxRowNumber.init(), XlsxColumnNumber.init());
-                buffer.accumulator().add(sheetName);
+                buffer.accumulator().add(sheetName, autoSizeColumnEnabled(sheet));
                 buffer.addressStack().push(address);
                 buffer.loopContext().put(new Index(), 0);
                 buffer.loopContext().put(new Item(sheet.item().toString()), map);
@@ -103,7 +104,7 @@ public class SheetHandler {
 
                     XlsxSheetName sheetName = new XlsxSheetName(new Name(entry.getKey()));
                     XlsxCellAddress address = new XlsxCellAddress(sheetName, XlsxRowNumber.init(), XlsxColumnNumber.init());
-                    buffer.accumulator().add(sheetName);
+                    buffer.accumulator().add(sheetName, autoSizeColumnEnabled(sheet));
                     buffer.addressStack().push(address);
                     buffer.loopContext().put(new Index(), 0);
                     buffer.loopContext().put(new Item(sheet.item().toString()), entry.getValue());
@@ -115,6 +116,21 @@ public class SheetHandler {
                 }
             }
         }
+    }
+
+    private Boolean autoSizeColumnEnabled(Sheet sheet) {
+        if (sheet.autoSizeColumn().isEmpty()) {
+            return null;
+        }
+
+        String value = sheet.autoSizeColumn().value().toLowerCase();
+        if ("true".equals(value)) {
+            return true;
+        }
+        if ("false".equals(value)) {
+            return false;
+        }
+        return null;
     }
 
     /**

--- a/src/main/java/io/luchta/forma4j/writer/engine/model/sheet/XlsxSheet.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/model/sheet/XlsxSheet.java
@@ -2,20 +2,32 @@ package io.luchta.forma4j.writer.engine.model.sheet;
 
 import io.luchta.forma4j.writer.engine.buffer.accumulater.support.ColumnPropertyMap;
 import io.luchta.forma4j.writer.engine.model.cell.XlsxCell;
-import io.luchta.forma4j.writer.engine.model.cell.XlsxCellList;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxSheetName;
 import io.luchta.forma4j.writer.engine.model.row.XlsxRow;
 import io.luchta.forma4j.writer.engine.model.row.XlsxRowList;
+
+import java.util.HashSet;
+import java.util.Set;
 
 public class XlsxSheet {
     XlsxSheetName name;
     XlsxRowList rows;
     ColumnPropertyMap columnPropertyMap;
+    Boolean autoSizeColumnEnabled;
+    int columnSize;
+    Set<Integer> nonEmptyColumnNumbers;
 
     public XlsxSheet(XlsxSheetName name, XlsxRowList rows, ColumnPropertyMap columnPropertyMap) {
+        this(name, rows, columnPropertyMap, null);
+    }
+
+    public XlsxSheet(XlsxSheetName name, XlsxRowList rows, ColumnPropertyMap columnPropertyMap, Boolean autoSizeColumnEnabled) {
         this.name = name;
         this.rows = rows;
         this.columnPropertyMap = columnPropertyMap;
+        this.autoSizeColumnEnabled = autoSizeColumnEnabled;
+        this.columnSize = columnSize(rows);
+        this.nonEmptyColumnNumbers = nonEmptyColumnNumbers(rows);
     }
 
     public XlsxSheetName name() {
@@ -30,20 +42,37 @@ public class XlsxSheet {
         return columnPropertyMap;
     }
 
+    public Boolean autoSizeColumnEnabled() {
+        return autoSizeColumnEnabled;
+    }
+
     public int columnSize() {
-        XlsxRow longestRow = rows.getLongest();
-        return longestRow.cells().size();
+        return columnSize;
     }
 
     public boolean isEmptyColumn(int index) {
+        return !nonEmptyColumnNumbers.contains(index);
+    }
+
+    private int columnSize(XlsxRowList rows) {
+        int maxColumnNumber = -1;
         for (XlsxRow row : rows) {
-            XlsxCellList cells = row.cells();
-            for (XlsxCell cell : cells) {
-                if (cell.columnNumber().toInt() == index && cell.isEmpty()) {
-                    return true;
+            for (XlsxCell cell : row.cells()) {
+                maxColumnNumber = Math.max(maxColumnNumber, cell.columnNumber().toInt());
+            }
+        }
+        return maxColumnNumber + 1;
+    }
+
+    private Set<Integer> nonEmptyColumnNumbers(XlsxRowList rows) {
+        Set<Integer> columnNumbers = new HashSet<>();
+        for (XlsxRow row : rows) {
+            for (XlsxCell cell : row.cells()) {
+                if (!cell.isEmpty()) {
+                    columnNumbers.add(cell.columnNumber().toInt());
                 }
             }
         }
-        return false;
+        return columnNumbers;
     }
 }

--- a/src/main/java/io/luchta/forma4j/writer/processor/poi/WorkbookBuilder.java
+++ b/src/main/java/io/luchta/forma4j/writer/processor/poi/WorkbookBuilder.java
@@ -198,7 +198,12 @@ public class WorkbookBuilder {
             }
         }
 
-        if (autoSizeColumnEnabled) {
+        boolean resolvedAutoSizeColumnEnabled = autoSizeColumnEnabled;
+        if (sheetModel.autoSizeColumnEnabled() != null) {
+            resolvedAutoSizeColumnEnabled = sheetModel.autoSizeColumnEnabled();
+        }
+
+        if (resolvedAutoSizeColumnEnabled) {
             for (int i = 0; i < sheetModel.columnSize(); i++) {
                 if (skipAutoSizeColumnNumberMap.containsKey(i) || sheetModel.isEmptyColumn(i)) {
                     continue;

--- a/src/test/java/io/luchta/forma4j/writer/engine/model/sheet/XlsxSheetTest.java
+++ b/src/test/java/io/luchta/forma4j/writer/engine/model/sheet/XlsxSheetTest.java
@@ -1,0 +1,50 @@
+package io.luchta.forma4j.writer.engine.model.sheet;
+
+import io.luchta.forma4j.writer.definition.schema.attribute.Name;
+import io.luchta.forma4j.writer.engine.buffer.accumulater.support.ColumnPropertyMap;
+import io.luchta.forma4j.writer.engine.model.cell.XlsxCell;
+import io.luchta.forma4j.writer.engine.model.cell.XlsxCellList;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxCellAddress;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxColumnNumber;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxRowNumber;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxSheetName;
+import io.luchta.forma4j.writer.engine.model.cell.style.XlsxCellStyle;
+import io.luchta.forma4j.writer.engine.model.cell.value.Text;
+import io.luchta.forma4j.writer.engine.model.row.XlsxRow;
+import io.luchta.forma4j.writer.engine.model.row.XlsxRowList;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+class XlsxSheetTest {
+    @Test
+    void columnMetadataIsCalculatedOnceFromCellAddresses() {
+        XlsxSheetName sheetName = new XlsxSheetName(new Name("sheet1"));
+        XlsxCellStyle style = new XlsxCellStyle();
+
+        XlsxCell nonEmptyCell = new XlsxCell(
+                new XlsxCellAddress(sheetName, new XlsxRowNumber(0L), new XlsxColumnNumber(5L)),
+                new Text("value"),
+                style,
+                null
+        );
+        XlsxCell emptyCell = new XlsxCell(
+                new XlsxCellAddress(sheetName, new XlsxRowNumber(1L), new XlsxColumnNumber(5L)),
+                new Text(""),
+                style,
+                null
+        );
+
+        XlsxRowList rows = new XlsxRowList(List.of(
+                new XlsxRow(new XlsxRowNumber(0L), new XlsxCellList(List.of(nonEmptyCell))),
+                new XlsxRow(new XlsxRowNumber(1L), new XlsxCellList(List.of(emptyCell)))
+        ));
+
+        XlsxSheet sheet = new XlsxSheet(sheetName, rows, new ColumnPropertyMap());
+
+        Assertions.assertEquals(6, sheet.columnSize());
+        Assertions.assertFalse(sheet.isEmptyColumn(5));
+        Assertions.assertTrue(sheet.isEmptyColumn(4));
+    }
+}

--- a/src/test/java/io/luchta/forma4j/writer/sheet/SheetTest.java
+++ b/src/test/java/io/luchta/forma4j/writer/sheet/SheetTest.java
@@ -6,10 +6,16 @@ import io.luchta.forma4j.context.databind.json.JsonNodes;
 import io.luchta.forma4j.context.databind.json.JsonObject;
 import io.luchta.forma4j.reader.FormaReader;
 import io.luchta.forma4j.writer.FormaWriter;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 import util.diff.FormaDiffer;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
@@ -74,5 +80,61 @@ public class SheetTest {
 
         Assertions.assertEquals(true, jsonObject.isJsonNodes());
         Assertions.assertEquals(0, ((JsonNodes) jsonObject.getValue()).size());
+    }
+
+    @Test
+    public void sheet_auto_size_column() throws Exception {
+        ClassLoader classLoader = getClass().getClassLoader();
+        JsonObject jsonObject = new JsonObject();
+        FormaWriter sut = new FormaWriter();
+
+        int disabledWidth;
+        int defaultWidth;
+        int enabledWidth;
+
+        try (InputStream in = classLoader.getResource("writer/sheet/sheet_auto_size_column.xml").openStream();
+             ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            sut.write(in, out, jsonObject);
+
+            try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(out.toByteArray()))) {
+                disabledWidth = columnWidth(workbook, "disabled");
+                defaultWidth = columnWidth(workbook, "default");
+                enabledWidth = columnWidth(workbook, "enabled");
+            }
+        }
+
+        Assertions.assertTrue(defaultWidth > disabledWidth);
+        Assertions.assertTrue(enabledWidth > disabledWidth);
+
+        byte[] templateBytes = templateBytes();
+        try (InputStream in = classLoader.getResource("writer/sheet/sheet_auto_size_column.xml").openStream();
+             ByteArrayOutputStream out = new ByteArrayOutputStream();
+             InputStream template = new ByteArrayInputStream(templateBytes)) {
+            sut.write(in, out, template, jsonObject);
+
+            try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(out.toByteArray()))) {
+                disabledWidth = columnWidth(workbook, "disabled");
+                defaultWidth = columnWidth(workbook, "default");
+                enabledWidth = columnWidth(workbook, "enabled");
+            }
+        }
+
+        Assertions.assertEquals(disabledWidth, defaultWidth);
+        Assertions.assertTrue(enabledWidth > defaultWidth);
+    }
+
+    private int columnWidth(Workbook workbook, String sheetName) {
+        Sheet sheet = workbook.getSheet(sheetName);
+        return sheet.getColumnWidth(0);
+    }
+
+    private byte[] templateBytes() throws Exception {
+        try (Workbook workbook = new XSSFWorkbook(); ByteArrayOutputStream out = new ByteArrayOutputStream()) {
+            workbook.createSheet("default");
+            workbook.createSheet("disabled");
+            workbook.createSheet("enabled");
+            workbook.write(out);
+            return out.toByteArray();
+        }
     }
 }

--- a/src/test/resources/writer/sheet/sheet_auto_size_column.xml
+++ b/src/test/resources/writer/sheet/sheet_auto_size_column.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<forma>
+  <sheet name="default">
+    <cell>abcdefghijklmnopqrstuvwxyz0123456789</cell>
+  </sheet>
+  <sheet name="disabled" autoSizeColumn="false">
+    <cell>abcdefghijklmnopqrstuvwxyz0123456789</cell>
+  </sheet>
+  <sheet name="enabled" autoSizeColumn="true">
+    <cell>abcdefghijklmnopqrstuvwxyz0123456789</cell>
+  </sheet>
+</forma>


### PR DESCRIPTION
* sheet タグに autoSizeColumn 属性を追加し、XML から列幅自動調整の有効・無効を制御
* 空列判定を前計算化し、autoSizeColumn 実行時の列ごとの全走査を解消