### PR TITLE
JsonObject から Context への変換効率化

### DIFF
--- a/src/main/java/io/luchta/forma4j/writer/Context.java
+++ b/src/main/java/io/luchta/forma4j/writer/Context.java
@@ -1,6 +1,12 @@
 package io.luchta.forma4j.writer;
 
+import io.luchta.forma4j.context.databind.json.JsonNode;
+import io.luchta.forma4j.context.databind.json.JsonNodes;
+import io.luchta.forma4j.context.databind.json.JsonObject;
+
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -13,6 +19,18 @@ public class Context {
         this.vars = vars;
     }
 
+    static Context from(JsonObject jsonObject) {
+        if (jsonObject == null || jsonObject.isEmpty()) {
+            return new Context();
+        }
+
+        if (!jsonObject.isJsonNode()) {
+            throw new IllegalArgumentException("ルート要素には JsonNode を指定してください。");
+        }
+
+        return new Context(toMap((JsonNode) jsonObject.getValue()));
+    }
+
     public void putVar(String key, Object value) {
         vars.put(key, value);
     }
@@ -23,5 +41,57 @@ public class Context {
 
     public Set<String> getKeys() {
         return vars.keySet();
+    }
+
+    private static Map<String, Object> toMap(JsonNode jsonNode) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        for (Map.Entry<String, JsonObject> entry : jsonNode.entrySet()) {
+            map.put(entry.getKey(), toValue(entry.getValue()));
+        }
+        return map;
+    }
+
+    private static List<Object> toList(JsonNodes jsonNodes) {
+        List<Object> list = new ArrayList<>();
+        for (JsonNode jsonNode : jsonNodes) {
+            list.add(toMap(jsonNode));
+        }
+        return list;
+    }
+
+    private static List<Object> toList(List<?> values) {
+        List<Object> list = new ArrayList<>();
+        for (Object value : values) {
+            if (value instanceof JsonObject) {
+                list.add(toValue((JsonObject) value));
+            } else if (value instanceof JsonNode) {
+                list.add(toMap((JsonNode) value));
+            } else if (value instanceof JsonNodes) {
+                list.add(toList((JsonNodes) value));
+            } else if (value instanceof List) {
+                list.add(toList((List<?>) value));
+            } else {
+                list.add(value);
+            }
+        }
+        return list;
+    }
+
+    private static Object toValue(JsonObject jsonObject) {
+        if (jsonObject == null || jsonObject.isEmpty()) {
+            return null;
+        }
+
+        Object value = jsonObject.getValue();
+        if (value instanceof JsonNode) {
+            return toMap((JsonNode) value);
+        }
+        if (value instanceof JsonNodes) {
+            return toList((JsonNodes) value);
+        }
+        if (value instanceof List) {
+            return toList((List<?>) value);
+        }
+        return value;
     }
 }

--- a/src/main/java/io/luchta/forma4j/writer/FormaWriter.java
+++ b/src/main/java/io/luchta/forma4j/writer/FormaWriter.java
@@ -1,10 +1,5 @@
 package io.luchta.forma4j.writer;
 
-import com.fasterxml.jackson.core.json.JsonReadFeature;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import io.luchta.forma4j.context.databind.convert.JsonSerializer;
 import io.luchta.forma4j.context.databind.json.JsonObject;
 import io.luchta.forma4j.writer.definition.XmlDocument;
 import io.luchta.forma4j.writer.definition.XmlDocumentReader;
@@ -17,8 +12,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 /**
  * {@code Writer} は設定ファイルに従って EXCEL の書き込みを行うクラスです。
@@ -125,24 +118,11 @@ public class FormaWriter {
     }
 
     private XlsxWriteProcessor processor(InputStream definitionXml, JsonObject jsonObject) throws IOException {
-        Context context = context(jsonObject);
-
         XmlDocumentReader definitionReader = new XmlDocumentReader();
         XmlDocument definition = definitionXml == null ? XmlDocument.defaultXmlDocument() : definitionReader.read(definitionXml);
-        XlsxModelBuilder modelBuilder = new XlsxModelBuilder(definition, context);
+        XlsxModelBuilder modelBuilder = new XlsxModelBuilder(definition, Context.from(jsonObject));
         XlsxBook model = modelBuilder.build();
         XlsxWriteProcessor processor = new XlsxWriteProcessor(model);
         return processor;
-    }
-
-    private Context context(JsonObject jsonObject) throws IOException {
-        JsonSerializer serializer = new JsonSerializer();
-        String json = serializer.serializeFromJsonObject(jsonObject);
-        TypeReference<LinkedHashMap<String, Object>> reference = new TypeReference<LinkedHashMap<String, Object>>() {};
-        ObjectMapper mapper = JsonMapper.builder()
-                .enable(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER)
-                .build();
-        Map<String, Object> map = mapper.readValue(json, reference);
-        return new Context(map);
     }
 }

--- a/src/main/java/io/luchta/forma4j/writer/Writer.java
+++ b/src/main/java/io/luchta/forma4j/writer/Writer.java
@@ -1,11 +1,6 @@
 package io.luchta.forma4j.writer;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.core.json.JsonReadFeature;
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.json.JsonMapper;
-import io.luchta.forma4j.context.databind.convert.JsonSerializer;
 import io.luchta.forma4j.context.databind.json.JsonObject;
 import io.luchta.forma4j.writer.definition.XmlDocument;
 import io.luchta.forma4j.writer.definition.XmlDocumentReader;
@@ -15,8 +10,6 @@ import io.luchta.forma4j.writer.processor.XlsxWriteProcessor;
 
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.LinkedHashMap;
-import java.util.Map;
 
 /**
  * {@code Writer} は設定ファイルに従って EXCEL の書き込みを行うクラスです。
@@ -36,33 +29,19 @@ import java.util.Map;
 @Deprecated
 public class Writer {
     public void write(OutputStream outputXlsx, JsonObject jsonObject) throws JsonProcessingException {
-        Context context = context(jsonObject);
         XmlDocument definition = XmlDocument.defaultXmlDocument();
-        XlsxModelBuilder modelBuilder = new XlsxModelBuilder(definition, context);
+        XlsxModelBuilder modelBuilder = new XlsxModelBuilder(definition, Context.from(jsonObject));
         XlsxBook model = modelBuilder.build();
         XlsxWriteProcessor processor = new XlsxWriteProcessor(model);
         processor.process(outputXlsx);
     }
 
     public void write(InputStream definitionXml, OutputStream outputXlsx, JsonObject jsonObject) throws JsonProcessingException {
-        Context context = context(jsonObject);
-
         XmlDocumentReader definitionReader = new XmlDocumentReader();
         XmlDocument definition = definitionReader.read(definitionXml);
-        XlsxModelBuilder modelBuilder = new XlsxModelBuilder(definition, context);
+        XlsxModelBuilder modelBuilder = new XlsxModelBuilder(definition, Context.from(jsonObject));
         XlsxBook model = modelBuilder.build();
         XlsxWriteProcessor processor = new XlsxWriteProcessor(model);
         processor.process(outputXlsx);
-    }
-
-    private Context context(JsonObject jsonObject) throws JsonProcessingException {
-        JsonSerializer serializer = new JsonSerializer();
-        String json = serializer.serializeFromJsonObject(jsonObject);
-        TypeReference<LinkedHashMap<String, Object>> reference = new TypeReference<LinkedHashMap<String, Object>>() {};
-        ObjectMapper mapper = JsonMapper.builder()
-                .enable(JsonReadFeature.ALLOW_BACKSLASH_ESCAPING_ANY_CHARACTER)
-                .build();
-        Map<String, Object> map = mapper.readValue(json, reference);
-        return new Context(map);
     }
 }

--- a/src/main/java/io/luchta/forma4j/writer/engine/resolver/VariableResolver.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/resolver/VariableResolver.java
@@ -145,6 +145,8 @@ public class VariableResolver {
         if (obj == null) return new Text();
         if (obj instanceof Number) return new Numeric(new BigDecimal(obj.toString()));
         if (obj instanceof Boolean) return new Bool((Boolean) obj);
+        if (obj instanceof LocalDate) return new Date((LocalDate) obj);
+        if (obj instanceof LocalDateTime) return new DateTime((LocalDateTime) obj);
 
         String s = String.valueOf(obj);
         try {


### PR DESCRIPTION
JsonObject -> Json 文字列 -> Context という変換処理を JsonObject -> Context として、不要な中間表現をなくして効率化を行なった。