### PR TITLE
独自中間モデルの長時間保持を改善

### DIFF
--- a/src/main/java/io/luchta/forma4j/writer/FormaWriter.java
+++ b/src/main/java/io/luchta/forma4j/writer/FormaWriter.java
@@ -4,7 +4,6 @@ import io.luchta.forma4j.context.databind.json.JsonObject;
 import io.luchta.forma4j.writer.definition.XmlDocument;
 import io.luchta.forma4j.writer.definition.XmlDocumentReader;
 import io.luchta.forma4j.writer.engine.XlsxModelBuilder;
-import io.luchta.forma4j.writer.engine.model.book.XlsxBook;
 import io.luchta.forma4j.writer.processor.XlsxPassword;
 import io.luchta.forma4j.writer.processor.XlsxWriteProcessor;
 
@@ -121,8 +120,7 @@ public class FormaWriter {
         XmlDocumentReader definitionReader = new XmlDocumentReader();
         XmlDocument definition = definitionXml == null ? XmlDocument.defaultXmlDocument() : definitionReader.read(definitionXml);
         XlsxModelBuilder modelBuilder = new XlsxModelBuilder(definition, Context.from(jsonObject));
-        XlsxBook model = modelBuilder.build();
-        XlsxWriteProcessor processor = new XlsxWriteProcessor(model);
+        XlsxWriteProcessor processor = new XlsxWriteProcessor(modelBuilder.accumulate());
         return processor;
     }
 }

--- a/src/main/java/io/luchta/forma4j/writer/Writer.java
+++ b/src/main/java/io/luchta/forma4j/writer/Writer.java
@@ -5,7 +5,6 @@ import io.luchta.forma4j.context.databind.json.JsonObject;
 import io.luchta.forma4j.writer.definition.XmlDocument;
 import io.luchta.forma4j.writer.definition.XmlDocumentReader;
 import io.luchta.forma4j.writer.engine.XlsxModelBuilder;
-import io.luchta.forma4j.writer.engine.model.book.XlsxBook;
 import io.luchta.forma4j.writer.processor.XlsxWriteProcessor;
 
 import java.io.InputStream;
@@ -31,8 +30,7 @@ public class Writer {
     public void write(OutputStream outputXlsx, JsonObject jsonObject) throws JsonProcessingException {
         XmlDocument definition = XmlDocument.defaultXmlDocument();
         XlsxModelBuilder modelBuilder = new XlsxModelBuilder(definition, Context.from(jsonObject));
-        XlsxBook model = modelBuilder.build();
-        XlsxWriteProcessor processor = new XlsxWriteProcessor(model);
+        XlsxWriteProcessor processor = new XlsxWriteProcessor(modelBuilder.accumulate());
         processor.process(outputXlsx);
     }
 
@@ -40,8 +38,7 @@ public class Writer {
         XmlDocumentReader definitionReader = new XmlDocumentReader();
         XmlDocument definition = definitionReader.read(definitionXml);
         XlsxModelBuilder modelBuilder = new XlsxModelBuilder(definition, Context.from(jsonObject));
-        XlsxBook model = modelBuilder.build();
-        XlsxWriteProcessor processor = new XlsxWriteProcessor(model);
+        XlsxWriteProcessor processor = new XlsxWriteProcessor(modelBuilder.accumulate());
         processor.process(outputXlsx);
     }
 }

--- a/src/main/java/io/luchta/forma4j/writer/engine/XlsxModelBuilder.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/XlsxModelBuilder.java
@@ -5,6 +5,7 @@ import io.luchta.forma4j.writer.definition.XmlDocument;
 import io.luchta.forma4j.writer.definition.schema.Element;
 import io.luchta.forma4j.writer.definition.schema.element.Sheet;
 import io.luchta.forma4j.writer.engine.buffer.BuildBuffer;
+import io.luchta.forma4j.writer.engine.buffer.accumulater.BuildAccumulator;
 import io.luchta.forma4j.writer.engine.handler.element.SheetHandler;
 import io.luchta.forma4j.writer.engine.model.book.XlsxBook;
 
@@ -17,10 +18,14 @@ public class XlsxModelBuilder {
         this.context = context;
     }
 
-    public XlsxBook build() {
+    public BuildAccumulator accumulate() {
         BuildBuffer buffer = new BuildBuffer(context);
         rootHandler(buffer);
-        return buffer.accumulator().toXlsxBook();
+        return buffer.accumulator();
+    }
+
+    public XlsxBook build() {
+        return accumulate().toXlsxBook();
     }
 
     private void rootHandler(BuildBuffer buffer) {

--- a/src/main/java/io/luchta/forma4j/writer/engine/buffer/accumulater/BuildAccumulator.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/buffer/accumulater/BuildAccumulator.java
@@ -66,8 +66,35 @@ public class BuildAccumulator {
     }
 
     public XlsxBook toXlsxBook() {
-        XlsxCellStyles styles = cells.toXlsxCellStyles();
-        return new XlsxBook(toSheetList(), styles);
+        return new XlsxBook(toSheetList(), styles());
+    }
+
+    public Iterable<XlsxSheetName> sheetNames() {
+        return sheetNameList;
+    }
+
+    public CellMap cells(XlsxSheetName sheetName) {
+        return cells.filterBy(sheetName);
+    }
+
+    public XlsxRowProperties rowProperties(XlsxRowAddress address) {
+        return rowPropertyMap.get(address);
+    }
+
+    public boolean hasRowProperties(XlsxRowAddress address) {
+        return rowPropertyMap.containsKey(address);
+    }
+
+    public ColumnPropertyMap columnProperties(XlsxSheetName sheetName) {
+        return columnPropertyMap.getBySheetName(sheetName);
+    }
+
+    public Boolean autoSizeColumnEnabled(XlsxSheetName sheetName) {
+        return autoSizeColumnEnabledMap.get(sheetName);
+    }
+
+    public XlsxCellStyles styles() {
+        return cells.toXlsxCellStyles();
     }
 
     private XlsxSheetList toSheetList() {

--- a/src/main/java/io/luchta/forma4j/writer/processor/XlsxWriteProcessor.java
+++ b/src/main/java/io/luchta/forma4j/writer/processor/XlsxWriteProcessor.java
@@ -1,5 +1,6 @@
 package io.luchta.forma4j.writer.processor;
 
+import io.luchta.forma4j.writer.engine.buffer.accumulater.BuildAccumulator;
 import io.luchta.forma4j.writer.engine.model.book.XlsxBook;
 import io.luchta.forma4j.writer.processor.poi.WorkbookBuilder;
 import org.apache.poi.ss.usermodel.Workbook;
@@ -21,14 +22,14 @@ public class XlsxWriteProcessor {
     /**
      * Excelへ書き込む内容
      */
-    XlsxBook model;
+    BuildAccumulator accumulator;
 
     /**
      * コンストラクタ
-     * @param model Excelへ書き込む内容
+     * @param accumulator Excelへ書き込む内容
      */
-    public XlsxWriteProcessor(XlsxBook model) {
-        this.model = model;
+    public XlsxWriteProcessor(BuildAccumulator accumulator) {
+        this.accumulator = accumulator;
     }
 
     /**
@@ -36,7 +37,7 @@ public class XlsxWriteProcessor {
      * @param out 書き込み先のファイル
      */
     public void process(OutputStream out) {
-        WorkbookBuilder builder = new WorkbookBuilder(model);
+        WorkbookBuilder builder = new WorkbookBuilder(accumulator);
         try (Workbook workbook = builder.build()) {
             workbook.write(out);
         } catch (IOException e) {
@@ -50,7 +51,7 @@ public class XlsxWriteProcessor {
      * @param in テンプレートファイル
      */
     public void process(OutputStream out, InputStream in) {
-        WorkbookBuilder builder = new WorkbookBuilder(model);
+        WorkbookBuilder builder = new WorkbookBuilder(accumulator);
         try (Workbook workbook = builder.build(in)) {
             workbook.write(out);
         } catch (IOException e) {

--- a/src/main/java/io/luchta/forma4j/writer/processor/poi/WorkbookBuilder.java
+++ b/src/main/java/io/luchta/forma4j/writer/processor/poi/WorkbookBuilder.java
@@ -1,27 +1,35 @@
 package io.luchta.forma4j.writer.processor.poi;
 
+import io.luchta.forma4j.writer.engine.buffer.accumulater.BuildAccumulator;
+import io.luchta.forma4j.writer.engine.buffer.accumulater.support.CellMap;
 import io.luchta.forma4j.writer.engine.buffer.accumulater.support.ColumnPropertyMap;
 import io.luchta.forma4j.writer.engine.model.book.XlsxBook;
 import io.luchta.forma4j.writer.engine.model.cell.XlsxCell;
+import io.luchta.forma4j.writer.engine.model.cell.XlsxCellList;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxColumnNumber;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxRowNumber;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxSheetName;
 import io.luchta.forma4j.writer.engine.model.cell.style.XlsxCellStyle;
-import io.luchta.forma4j.writer.engine.model.cell.value.XlsxCellValue;
 import io.luchta.forma4j.writer.engine.model.column.XlsxColumnAddress;
 import io.luchta.forma4j.writer.engine.model.column.XlsxColumnRange;
 import io.luchta.forma4j.writer.engine.model.column.property.WidthProperty;
 import io.luchta.forma4j.writer.engine.model.column.property.XlsxColumnProperties;
 import io.luchta.forma4j.writer.engine.model.column.property.XlsxColumnProperty;
-import io.luchta.forma4j.writer.engine.model.row.XlsxRow;
-import io.luchta.forma4j.writer.engine.model.sheet.XlsxSheet;
-import org.apache.poi.ss.usermodel.*;
+import io.luchta.forma4j.writer.engine.model.row.address.XlsxRowAddress;
+import io.luchta.forma4j.writer.engine.model.row.property.AutoFilterProperty;
+import io.luchta.forma4j.writer.engine.model.row.property.XlsxRowProperties;
+import io.luchta.forma4j.writer.engine.model.row.property.XlsxRowProperty;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.ss.usermodel.Row;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
 import org.apache.poi.ss.util.CellRangeAddress;
 import org.apache.poi.xssf.usermodel.XSSFWorkbook;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.math.BigDecimal;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -32,58 +40,41 @@ import java.util.Map;
  * </p>
  */
 public class WorkbookBuilder {
-    /** モデル */
-    XlsxBook model;
+    BuildAccumulator accumulator;
 
-    /**
-     * コンストラクタ
-     * @param model
-     */
-    public WorkbookBuilder(XlsxBook model) {
-        this.model = model;
+    public WorkbookBuilder(BuildAccumulator accumulator) {
+        this.accumulator = accumulator;
     }
 
-    /**
-     * 新規Excelワークブック作成
-     * @return ワークブック
-     */
     public Workbook build() {
         return build(new XSSFWorkbook(), true, false);
     }
 
-    /**
-     * 既存のExcelワークブックへ出力
-     * @param in テンプレート
-     * @return ワークブック
-     * @throws IOException
-     */
     public Workbook build(InputStream in) throws IOException {
         return build(WorkbookFactory.create(in), false, true);
     }
 
-    /**
-     * Excelワークブック作成
-     * @param workbook ワークブック
-     * @param autoSizeColumnEnabled true: 列幅自動調整あり, false: 列幅自動調整なし
-     * @param previousCellStyle true: 既存セルの書式を変更せずに出力, false: 既存セルの書式を上書き
-     * @return ワークブック
-     */
     private Workbook build(Workbook workbook, boolean autoSizeColumnEnabled, boolean previousCellStyle) {
         Map<XlsxCellStyle, CellStyle> styleMap = makeStyleMap(workbook);
 
-        for (XlsxSheet sheetModel : model.sheets()) {
-            Sheet sheet = workbook.getSheet(sheetModel.name().toString());
+        for (XlsxSheetName sheetName : accumulator.sheetNames()) {
+            Sheet sheet = workbook.getSheet(sheetName.toString());
             if (sheet == null) {
-                sheet = workbook.createSheet(sheetModel.name().toString());
+                sheet = workbook.createSheet(sheetName.toString());
             }
 
-            for (XlsxRow rowModel : sheetModel.rows()) {
-                Row row = sheet.getRow(rowModel.rowNumber().toInt());
+            CellMap sheetCells = accumulator.cells(sheetName);
+            int columnSize = -1;
+            Map<Integer, Integer> nonEmptyColumnNumbers = new HashMap<>();
+
+            for (XlsxRowNumber rowNumber : sheetCells.rowNumberList()) {
+                Row row = sheet.getRow(rowNumber.toInt());
                 if (row == null) {
-                    row = sheet.createRow(rowModel.rowNumber().toInt());
+                    row = sheet.createRow(rowNumber.toInt());
                 }
 
-                for (XlsxCell cellModel : rowModel.cells()) {
+                XlsxCellList rowCells = sheetCells.filterBy(rowNumber).toXlsxCellList();
+                for (XlsxCell cellModel : rowCells) {
                     Cell cell = row.getCell(cellModel.columnNumber().toInt());
                     if (cell == null) {
                         cell = row.createCell(cellModel.columnNumber().toInt());
@@ -95,14 +86,18 @@ public class WorkbookBuilder {
                         cell.setCellStyle(styleMap.get(cellModel.style()));
                     }
                     cellValue(cell, cellModel);
+                    columnSize = Math.max(columnSize, cellModel.columnNumber().toInt());
+                    if (!cellModel.isEmpty()) {
+                        nonEmptyColumnNumbers.put(cellModel.columnNumber().toInt(), cellModel.columnNumber().toInt());
+                    }
                 }
 
-                if (rowModel.hasAutoFilter()) {
-                    XlsxColumnRange range = rowModel.columnRange();
+                if (hasAutoFilter(sheetName, rowNumber)) {
+                    XlsxColumnRange range = columnRange(rowCells);
                     sheet.setAutoFilter(
                             new CellRangeAddress(
-                                    rowModel.rowNumber().toInt(),
-                                    rowModel.rowNumber().toInt(),
+                                    rowNumber.toInt(),
+                                    rowNumber.toInt(),
                                     range.firstColumnNumber().toInt(),
                                     range.lastColumnNumber().toInt()
                             )
@@ -110,22 +105,14 @@ public class WorkbookBuilder {
                 }
             }
 
-            setColumnStyle(sheetModel, sheet, autoSizeColumnEnabled);
+            setColumnStyle(sheetName, sheet, autoSizeColumnEnabled, columnSize + 1, nonEmptyColumnNumbers);
         }
         return workbook;
     }
 
-    /**
-     * スタイル作成
-     * <p>
-     * 作成したスタイルを{@link Map}にプットして同じスタイルを複数作成しないようにします。
-     * </p>
-     * @param workbook
-     * @return スタイル
-     */
     private Map<XlsxCellStyle, CellStyle> makeStyleMap(Workbook workbook) {
         Map<XlsxCellStyle, CellStyle> map = new HashMap<>();
-        for (XlsxCellStyle style : model.styles()) {
+        for (XlsxCellStyle style : accumulator.styles()) {
             CellStyleBuilder builder = CellStyleBuilder.of(style, workbook);
             CellStyle cellStyle = builder.build();
             map.put(style, cellStyle);
@@ -133,14 +120,6 @@ public class WorkbookBuilder {
         return map;
     }
 
-    /**
-     * セルの値をセット
-     * <p>
-     * 先頭が = で始まるときは計算式として扱います
-     * </p>
-     * @param cell
-     * @param cellModel
-     */
     private void cellValue(Cell cell, XlsxCell cellModel) {
         try {
             if (cellModel.isEmpty()) {
@@ -179,14 +158,14 @@ public class WorkbookBuilder {
         }
     }
 
-    /**
-     * 列のスタイル設定
-     * @param sheetModel
-     * @param sheet
-     * @param autoSizeColumnEnabled
-     */
-    private void setColumnStyle(XlsxSheet sheetModel, Sheet sheet, boolean autoSizeColumnEnabled) {
-        ColumnPropertyMap map = sheetModel.columnPropertyMap();
+    private void setColumnStyle(
+            XlsxSheetName sheetName,
+            Sheet sheet,
+            boolean autoSizeColumnEnabled,
+            int columnSize,
+            Map<Integer, Integer> nonEmptyColumnNumbers
+    ) {
+        ColumnPropertyMap map = accumulator.columnProperties(sheetName);
         Map<Integer, Integer> skipAutoSizeColumnNumberMap = new HashMap<>();
         for (Map.Entry<XlsxColumnAddress, XlsxColumnProperties> entry : map.entrySet()) {
             XlsxColumnNumber columnNumber = entry.getKey().columnNumber();
@@ -199,17 +178,48 @@ public class WorkbookBuilder {
         }
 
         boolean resolvedAutoSizeColumnEnabled = autoSizeColumnEnabled;
-        if (sheetModel.autoSizeColumnEnabled() != null) {
-            resolvedAutoSizeColumnEnabled = sheetModel.autoSizeColumnEnabled();
+        if (accumulator.autoSizeColumnEnabled(sheetName) != null) {
+            resolvedAutoSizeColumnEnabled = accumulator.autoSizeColumnEnabled(sheetName);
         }
 
         if (resolvedAutoSizeColumnEnabled) {
-            for (int i = 0; i < sheetModel.columnSize(); i++) {
-                if (skipAutoSizeColumnNumberMap.containsKey(i) || sheetModel.isEmptyColumn(i)) {
+            for (int i = 0; i < columnSize; i++) {
+                if (skipAutoSizeColumnNumberMap.containsKey(i) || !nonEmptyColumnNumbers.containsKey(i)) {
                     continue;
                 }
                 sheet.autoSizeColumn(i);
             }
         }
+    }
+
+    private boolean hasAutoFilter(XlsxSheetName sheetName, XlsxRowNumber rowNumber) {
+        XlsxRowAddress rowAddress = new XlsxRowAddress(sheetName, rowNumber);
+        if (!accumulator.hasRowProperties(rowAddress)) {
+            return false;
+        }
+
+        XlsxRowProperties properties = accumulator.rowProperties(rowAddress);
+        for (XlsxRowProperty property : properties) {
+            if (property instanceof AutoFilterProperty) {
+                return ((AutoFilterProperty) property).booleanValue();
+            }
+        }
+        return false;
+    }
+
+    private XlsxColumnRange columnRange(XlsxCellList cells) {
+        if (cells.size() == 0) {
+            return new XlsxColumnRange();
+        }
+
+        XlsxColumnNumber firstColumnNumber = null;
+        XlsxColumnNumber lastColumnNumber = null;
+        for (XlsxCell cell : cells) {
+            if (firstColumnNumber == null) {
+                firstColumnNumber = cell.columnNumber();
+            }
+            lastColumnNumber = cell.columnNumber();
+        }
+        return new XlsxColumnRange(firstColumnNumber, lastColumnNumber);
     }
 }


### PR DESCRIPTION
メモリ使用の効率化のため、独自中間モデルの長時間保持を改善。`XlsxBook` を全件構築した後に `POI Workbook` を全件構築しているのを、BuildAccumulator から POI への逐次反映に変更