### PR TITLE
再フィルタや再構築の繰り返しを改善

### DIFF
--- a/src/main/java/io/luchta/forma4j/writer/engine/buffer/accumulater/BuildAccumulator.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/buffer/accumulater/BuildAccumulator.java
@@ -6,8 +6,8 @@ import io.luchta.forma4j.writer.engine.buffer.accumulater.support.RowPropertyMap
 import io.luchta.forma4j.writer.engine.buffer.accumulater.support.SheetNameList;
 import io.luchta.forma4j.writer.engine.model.book.XlsxBook;
 import io.luchta.forma4j.writer.engine.model.cell.XlsxCell;
-import io.luchta.forma4j.writer.engine.model.cell.XlsxCellList;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxCellAddress;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxColumnNumber;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxRowNumber;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxSheetName;
 import io.luchta.forma4j.writer.engine.model.cell.style.XlsxCellStyles;
@@ -73,8 +73,8 @@ public class BuildAccumulator {
         return sheetNameList;
     }
 
-    public CellMap cells(XlsxSheetName sheetName) {
-        return cells.filterBy(sheetName);
+    public Map<XlsxRowNumber, Map<XlsxColumnNumber, XlsxCell>> rows(XlsxSheetName sheetName) {
+        return cells.rows(sheetName);
     }
 
     public XlsxRowProperties rowProperties(XlsxRowAddress address) {
@@ -112,20 +112,16 @@ public class BuildAccumulator {
     }
 
     private XlsxRowList toRowList(XlsxSheetName sheetName) {
-        CellMap thisSheetCells = cells.filterBy(sheetName);
         List<XlsxRow> list = new ArrayList<>();
-        for (XlsxRowNumber rowNumber : thisSheetCells.rowNumberList()) {
-            XlsxCellList thisRowCellList = thisSheetCells
-                    .filterBy(rowNumber)
-                    .toXlsxCellList();
-
+        for (Map.Entry<XlsxRowNumber, Map<XlsxColumnNumber, XlsxCell>> rowEntry : cells.rows(sheetName).entrySet()) {
+            XlsxRowNumber rowNumber = rowEntry.getKey();
             XlsxRowAddress rowAddress = new XlsxRowAddress(sheetName, rowNumber);
             if (rowPropertyMap.containsKey(rowAddress)) {
                 XlsxRowProperties properties = rowPropertyMap.get(rowAddress);
-                list.add(new XlsxRow(rowNumber, thisRowCellList, properties));
+                list.add(new XlsxRow(rowNumber, cells.toXlsxCellList(rowEntry.getValue()), properties));
                 continue;
             }
-            list.add(new XlsxRow(rowNumber, thisRowCellList));
+            list.add(new XlsxRow(rowNumber, cells.toXlsxCellList(rowEntry.getValue())));
         }
         return new XlsxRowList(list);
     }

--- a/src/main/java/io/luchta/forma4j/writer/engine/buffer/accumulater/support/CellMap.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/buffer/accumulater/support/CellMap.java
@@ -3,67 +3,64 @@ package io.luchta.forma4j.writer.engine.buffer.accumulater.support;
 import io.luchta.forma4j.writer.engine.model.cell.XlsxCell;
 import io.luchta.forma4j.writer.engine.model.cell.XlsxCellList;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxCellAddress;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxColumnNumber;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxRowNumber;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxSheetName;
 import io.luchta.forma4j.writer.engine.model.cell.style.XlsxCellStyle;
 import io.luchta.forma4j.writer.engine.model.cell.style.XlsxCellStyles;
 
-import java.util.Comparator;
-import java.util.HashSet;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.stream.Collectors;
+import java.util.TreeMap;
 
 public class CellMap {
-    Map<XlsxCellAddress, XlsxCell> map = new HashMap<>();
-
-    public CellMap() {
-    }
-
-    public CellMap(Map<XlsxCellAddress, XlsxCell> map) {
-        this.map = map;
-    }
+    Map<XlsxSheetName, Map<XlsxRowNumber, Map<XlsxColumnNumber, XlsxCell>>> sheetRowColumnMap = new HashMap<>();
 
     public void put(XlsxCellAddress address, XlsxCell cell) {
-        map.put(address, cell);
+        Map<XlsxRowNumber, Map<XlsxColumnNumber, XlsxCell>> rowMap = sheetRowColumnMap.computeIfAbsent(
+                address.sheetName(),
+                key -> new TreeMap<>()
+        );
+        Map<XlsxColumnNumber, XlsxCell> columnMap = rowMap.computeIfAbsent(
+                address.rowNumber(),
+                key -> new TreeMap<>()
+        );
+        columnMap.put(address.columnNumber(), cell);
     }
 
-    public CellMap filterBy(XlsxSheetName sheetName) {
-        Map<XlsxCellAddress, XlsxCell> filtered = map.entrySet().stream()
-                .filter(entry -> entry.getKey().is(sheetName))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        return new CellMap(filtered);
+    public Map<XlsxRowNumber, Map<XlsxColumnNumber, XlsxCell>> rows(XlsxSheetName sheetName) {
+        if (!sheetRowColumnMap.containsKey(sheetName)) {
+            return Collections.emptyMap();
+        }
+        return sheetRowColumnMap.get(sheetName);
     }
 
-    public CellMap filterBy(XlsxRowNumber rowNumber) {
-        Map<XlsxCellAddress, XlsxCell> filtered = map.entrySet().stream()
-                .filter(entry -> entry.getKey().is(rowNumber))
-                .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
-        return new CellMap(filtered);
+    public Iterable<XlsxCell> cells(XlsxSheetName sheetName, XlsxRowNumber rowNumber) {
+        Map<XlsxRowNumber, Map<XlsxColumnNumber, XlsxCell>> rowMap = rows(sheetName);
+        if (!rowMap.containsKey(rowNumber)) {
+            return Collections.emptyList();
+        }
+        return rowMap.get(rowNumber).values();
     }
 
-    public RowNumberList rowNumberList() {
-        List<XlsxRowNumber> sorted = map.keySet().stream()
-                .map(XlsxCellAddress::rowNumber)
-                .distinct()
-                .sorted()
-                .collect(Collectors.toList());
-        return new RowNumberList(sorted);
-    }
-
-    public XlsxCellList toXlsxCellList() {
-        List<XlsxCell> sorted = map.values().stream()
-                .sorted(Comparator.comparing(o -> o.address().columnNumber()))
-                .collect(Collectors.toList());
-        return new XlsxCellList(sorted);
+    public XlsxCellList toXlsxCellList(Map<XlsxColumnNumber, XlsxCell> rowCells) {
+        List<XlsxCell> cells = new ArrayList<>(rowCells.values());
+        return new XlsxCellList(cells);
     }
 
     public XlsxCellStyles toXlsxCellStyles() {
         Set<XlsxCellStyle> styles = new HashSet<>();
-        for (XlsxCell cell : map.values()) {
-            styles.add(cell.style());
+        for (Map<XlsxRowNumber, Map<XlsxColumnNumber, XlsxCell>> rowMap : sheetRowColumnMap.values()) {
+            for (Map<XlsxColumnNumber, XlsxCell> columnMap : rowMap.values()) {
+                for (XlsxCell cell : columnMap.values()) {
+                    styles.add(cell.style());
+                }
+            }
         }
         return new XlsxCellStyles(styles);
     }

--- a/src/main/java/io/luchta/forma4j/writer/processor/poi/WorkbookBuilder.java
+++ b/src/main/java/io/luchta/forma4j/writer/processor/poi/WorkbookBuilder.java
@@ -1,11 +1,8 @@
 package io.luchta.forma4j.writer.processor.poi;
 
 import io.luchta.forma4j.writer.engine.buffer.accumulater.BuildAccumulator;
-import io.luchta.forma4j.writer.engine.buffer.accumulater.support.CellMap;
 import io.luchta.forma4j.writer.engine.buffer.accumulater.support.ColumnPropertyMap;
-import io.luchta.forma4j.writer.engine.model.book.XlsxBook;
 import io.luchta.forma4j.writer.engine.model.cell.XlsxCell;
-import io.luchta.forma4j.writer.engine.model.cell.XlsxCellList;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxColumnNumber;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxRowNumber;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxSheetName;
@@ -35,9 +32,6 @@ import java.util.Map;
 
 /**
  * ワークブックビルドクラス
- * <p>
- * {@link XlsxBook} の内容を読み取ってExcelワークブック作成を行います。
- * </p>
  */
 public class WorkbookBuilder {
     BuildAccumulator accumulator;
@@ -63,18 +57,19 @@ public class WorkbookBuilder {
                 sheet = workbook.createSheet(sheetName.toString());
             }
 
-            CellMap sheetCells = accumulator.cells(sheetName);
             int columnSize = -1;
             Map<Integer, Integer> nonEmptyColumnNumbers = new HashMap<>();
 
-            for (XlsxRowNumber rowNumber : sheetCells.rowNumberList()) {
+            for (Map.Entry<XlsxRowNumber, Map<XlsxColumnNumber, XlsxCell>> rowEntry : accumulator.rows(sheetName).entrySet()) {
+                XlsxRowNumber rowNumber = rowEntry.getKey();
                 Row row = sheet.getRow(rowNumber.toInt());
                 if (row == null) {
                     row = sheet.createRow(rowNumber.toInt());
                 }
 
-                XlsxCellList rowCells = sheetCells.filterBy(rowNumber).toXlsxCellList();
-                for (XlsxCell cellModel : rowCells) {
+                XlsxColumnNumber firstColumnNumber = null;
+                XlsxColumnNumber lastColumnNumber = null;
+                for (XlsxCell cellModel : rowEntry.getValue().values()) {
                     Cell cell = row.getCell(cellModel.columnNumber().toInt());
                     if (cell == null) {
                         cell = row.createCell(cellModel.columnNumber().toInt());
@@ -90,10 +85,14 @@ public class WorkbookBuilder {
                     if (!cellModel.isEmpty()) {
                         nonEmptyColumnNumbers.put(cellModel.columnNumber().toInt(), cellModel.columnNumber().toInt());
                     }
+                    if (firstColumnNumber == null) {
+                        firstColumnNumber = cellModel.columnNumber();
+                    }
+                    lastColumnNumber = cellModel.columnNumber();
                 }
 
                 if (hasAutoFilter(sheetName, rowNumber)) {
-                    XlsxColumnRange range = columnRange(rowCells);
+                    XlsxColumnRange range = new XlsxColumnRange(firstColumnNumber, lastColumnNumber);
                     sheet.setAutoFilter(
                             new CellRangeAddress(
                                     rowNumber.toInt(),
@@ -205,21 +204,5 @@ public class WorkbookBuilder {
             }
         }
         return false;
-    }
-
-    private XlsxColumnRange columnRange(XlsxCellList cells) {
-        if (cells.size() == 0) {
-            return new XlsxColumnRange();
-        }
-
-        XlsxColumnNumber firstColumnNumber = null;
-        XlsxColumnNumber lastColumnNumber = null;
-        for (XlsxCell cell : cells) {
-            if (firstColumnNumber == null) {
-                firstColumnNumber = cell.columnNumber();
-            }
-            lastColumnNumber = cell.columnNumber();
-        }
-        return new XlsxColumnRange(firstColumnNumber, lastColumnNumber);
     }
 }


### PR DESCRIPTION
シート単位、行単位の再フィルタで HashMap を都度生成しているため再フィルタ、再構築を行わないように修正。