### PR TITLE
shaded jar の POI サービス読み込みを修正 #408

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = 'io.luchta'
-version = '1.9.1'
+version = '1.9.2'
 
 sourceCompatibility = compatibility
 targetCompatibility = compatibility
@@ -128,7 +128,7 @@ jreleaser {
 
 shadowJar {
     archiveClassifier.set("")
-    relocate 'org.apache.poi', 'io.luchta.forma4j.shaded.poi'
+    mergeServiceFiles()
 }
 
 tasks.named("publishShadowPublicationToLocalStagingRepository") {


### PR DESCRIPTION
## 概要

v1.9.1 で追加した POI の relocation 設定を削除し、shaded jar 作成時に `META-INF/services` をマージするよう修正。

## 背景

Excel 出力結果が破損するケースがあり、原因は `shadowJar` で POI を relocation したことで、POI の `WorkbookFactory` が利用する service provider の解決が壊れていたため。

## 変更内容

- `relocate 'org.apache.poi', 'io.luchta.forma4j.shaded.poi'` を削除
- `shadowJar` に `mergeServiceFiles()` を追加

## 確認内容

- `./gradlew clean test shadowJar --stacktrace`
- 生成された shaded jar に `io/luchta/forma4j/shaded/poi` が含まれないことを確認
- shaded jar 単体でテンプレート `.xlsx` 入力が成功することを確認
- 出力 `.xlsx` を開き、破損していないことを確認