### PR TITLE
Excel出力におけるメモリ使用量の改善

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,7 +16,7 @@ plugins {
 }
 
 group = 'io.luchta'
-version = '1.10.0'
+version = '1.10.0-SNAPSHOT'
 
 sourceCompatibility = compatibility
 targetCompatibility = compatibility
@@ -51,7 +51,21 @@ dependencies {
 }
 
 test {
-    useJUnitPlatform()
+    useJUnitPlatform {
+        excludeTags 'low-heap'
+    }
+}
+
+tasks.register('lowHeapTest', Test) {
+    description = 'Runs low-memory streaming writer tests with a 256 MiB heap.'
+    group = 'verification'
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    maxHeapSize = '256m'
+    useJUnitPlatform {
+        includeTags 'low-heap'
+    }
+    shouldRunAfter test
 }
 
 repositories {

--- a/docs/java/java.md
+++ b/docs/java/java.md
@@ -78,3 +78,50 @@ public class FormaReaderExample {
   }
 }
 ```
+
+## 大量データをストリーミング出力する
+
+`FormaStreamingWriter` は `Context` を直接受け取り、複数の名前付きデータを
+1回の出力で使用できます。`Context` へ登録したMapやIterableは再帰コピーされません。
+
+```java
+import io.luchta.forma4j.writer.Context;
+import io.luchta.forma4j.writer.stream.FormaStreamingWriter;
+import io.luchta.forma4j.writer.stream.JsonArraySequenceSource;
+
+import java.nio.file.Files;
+
+Context context = new Context();
+context.putVar("generatedAt", generatedAt);
+context.putVar("headers", headerIterable);
+context.putSequence(
+    "rows",
+    JsonArraySequenceSource.from(() -> Files.newInputStream(rowsJson))
+);
+
+new FormaStreamingWriter().write(
+    definitionXml,
+    outputXlsx,
+    templateXlsx,
+    context
+);
+```
+
+XMLでは登録名を通常のcollection名として参照します。
+
+```xml
+<horizontal-for item="header" collection="headers">
+  <cell>#{header}</cell>
+</horizontal-for>
+<vertical-for item="row" collection="rows">
+  <row><cell>#{row.name}</cell></row>
+</vertical-for>
+```
+
+- `IterableSequenceSource.oneShot(iterator)` は1回だけ参照できます。
+- `IterableSequenceSource.replayable(iterable)` と
+  `JsonArraySequenceSource.from(supplier)` は参照ごとに先頭から開き直します。
+- `SpooledSequenceSource.from(source)` はJSON互換値を一時ファイルへ退避し、
+  複数回参照できるようにします。
+- Supplierから開いたInputStreamとiteratorはWriterが閉じます。
+- `write` へ直接渡したdefinition、template、JSON、outputのStreamは閉じません。

--- a/src/main/java/io/luchta/forma4j/writer/Context.java
+++ b/src/main/java/io/luchta/forma4j/writer/Context.java
@@ -3,11 +3,13 @@ package io.luchta.forma4j.writer;
 import io.luchta.forma4j.context.databind.json.JsonNode;
 import io.luchta.forma4j.context.databind.json.JsonNodes;
 import io.luchta.forma4j.context.databind.json.JsonObject;
+import io.luchta.forma4j.writer.stream.SequenceSource;
 
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 public class Context {
@@ -19,7 +21,7 @@ public class Context {
         this.vars = vars;
     }
 
-    static Context from(JsonObject jsonObject) {
+    public static Context from(JsonObject jsonObject) {
         if (jsonObject == null || jsonObject.isEmpty()) {
             return new Context();
         }
@@ -33,6 +35,16 @@ public class Context {
 
     public void putVar(String key, Object value) {
         vars.put(key, value);
+    }
+
+    /**
+     * 名前付きのストリーミングコレクションを登録します。
+     *
+     * @param key XML の collection 属性から参照する名前
+     * @param source コレクションを開くSource
+     */
+    public void putSequence(String key, SequenceSource<?> source) {
+        vars.put(key, Objects.requireNonNull(source, "source"));
     }
 
     public Object getVar(String key) {

--- a/src/main/java/io/luchta/forma4j/writer/engine/XlsxModelBuilder.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/XlsxModelBuilder.java
@@ -8,6 +8,9 @@ import io.luchta.forma4j.writer.engine.buffer.BuildBuffer;
 import io.luchta.forma4j.writer.engine.buffer.accumulater.BuildAccumulator;
 import io.luchta.forma4j.writer.engine.handler.element.SheetHandler;
 import io.luchta.forma4j.writer.engine.model.book.XlsxBook;
+import io.luchta.forma4j.writer.engine.resolver.VariableResolver;
+import io.luchta.forma4j.writer.engine.strategy.AccumulatingOutputStrategy;
+import io.luchta.forma4j.writer.engine.strategy.XlsxOutputStrategy;
 
 public class XlsxModelBuilder {
     XmlDocument definition;
@@ -19,13 +22,28 @@ public class XlsxModelBuilder {
     }
 
     public BuildAccumulator accumulate() {
-        BuildBuffer buffer = new BuildBuffer(context);
-        rootHandler(buffer);
-        return buffer.accumulator();
+        AccumulatingOutputStrategy strategy = new AccumulatingOutputStrategy();
+        write(strategy);
+        return strategy.accumulator();
     }
 
     public XlsxBook build() {
         return accumulate().toXlsxBook();
+    }
+
+    /** 定義を指定した出力戦略へ展開します。 */
+    public void write(XlsxOutputStrategy outputStrategy) {
+        BuildBuffer buffer = new BuildBuffer(context, outputStrategy);
+        rootHandler(buffer);
+    }
+
+    /** Sourceを開く処理を指定して定義を出力戦略へ展開します。 */
+    public void write(
+            XlsxOutputStrategy outputStrategy,
+            VariableResolver.SequenceOpener sequenceOpener
+    ) {
+        BuildBuffer buffer = new BuildBuffer(context, outputStrategy, sequenceOpener);
+        rootHandler(buffer);
     }
 
     private void rootHandler(BuildBuffer buffer) {

--- a/src/main/java/io/luchta/forma4j/writer/engine/buffer/BuildBuffer.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/buffer/BuildBuffer.java
@@ -6,20 +6,46 @@ import io.luchta.forma4j.writer.engine.buffer.loop.LoopContext;
 import io.luchta.forma4j.writer.engine.buffer.stack.AddressStack;
 import io.luchta.forma4j.writer.engine.resolver.StyleResolver;
 import io.luchta.forma4j.writer.engine.resolver.VariableResolver;
+import io.luchta.forma4j.writer.engine.strategy.AccumulatingOutputStrategy;
+import io.luchta.forma4j.writer.engine.strategy.XlsxOutputStrategy;
 
 public class BuildBuffer {
-    BuildAccumulator accumulator = new BuildAccumulator();
+    XlsxOutputStrategy outputStrategy;
     AddressStack addressStack = new AddressStack();
     LoopContext loopContext = new LoopContext();
     VariableResolver variableResolver;
     StyleResolver styleResolver = new StyleResolver();
 
     public BuildBuffer(Context context) {
-        this.variableResolver = new VariableResolver(context, loopContext);
+        this(context, new AccumulatingOutputStrategy());
     }
 
+    public BuildBuffer(Context context, XlsxOutputStrategy outputStrategy) {
+        this(context, outputStrategy, null);
+    }
+
+    public BuildBuffer(
+            Context context,
+            XlsxOutputStrategy outputStrategy,
+            VariableResolver.SequenceOpener sequenceOpener
+    ) {
+        this.outputStrategy = outputStrategy;
+        this.variableResolver = sequenceOpener == null
+                ? new VariableResolver(context, loopContext)
+                : new VariableResolver(context, loopContext, sequenceOpener);
+    }
+
+    /** @deprecated ハンドラからは {@link #outputStrategy()} を使用してください。 */
+    @Deprecated
     public BuildAccumulator accumulator() {
-        return accumulator;
+        if (outputStrategy instanceof AccumulatingOutputStrategy) {
+            return ((AccumulatingOutputStrategy) outputStrategy).accumulator();
+        }
+        throw new IllegalStateException("蓄積方式ではない出力戦略に accumulator はありません。");
+    }
+
+    public XlsxOutputStrategy outputStrategy() {
+        return outputStrategy;
     }
 
     public AddressStack addressStack() {

--- a/src/main/java/io/luchta/forma4j/writer/engine/handler/element/CellHandler.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/handler/element/CellHandler.java
@@ -67,9 +67,9 @@ public class CellHandler {
         XlsxColumnProperties columnProperties = resolvedStyle.columnProperties();
 
         // 設定した内容をbufferへセットする
-        buffer.accumulator().put(address, xlsxCell);
+        buffer.outputStrategy().writeCell(address, xlsxCell);
         for (XlsxColumnProperty columnProperty : columnProperties) {
-            buffer.accumulator().putColumnProperties(columnAddress, columnProperty);
+            buffer.outputStrategy().writeColumnProperty(columnAddress, columnProperty);
         }
     }
 

--- a/src/main/java/io/luchta/forma4j/writer/engine/handler/element/HorizontalForHandler.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/handler/element/HorizontalForHandler.java
@@ -11,8 +11,6 @@ import io.luchta.forma4j.writer.engine.model.cell.address.XlsxColumnNumber;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxRowNumber;
 import io.luchta.forma4j.writer.engine.resolver.VariableResolver;
 
-import java.util.List;
-
 /**
  * horizontal-forタグのハンドラ
  */
@@ -36,7 +34,6 @@ public class HorizontalForHandler {
      */
     public void handle(HorizontalFor horizontalFor) {
         VariableResolver variableResolver = buffer.variableResolver();
-        List<Object> collection = variableResolver.getList(horizontalFor.collection().toString());
         XlsxCellAddress baseAddress = buffer.addressStack().peek();
         XlsxRowNumber startRowNumber = horizontalFor.startRowIndex().isEmpty()
                 ? baseAddress.rowNumber()
@@ -44,20 +41,24 @@ public class HorizontalForHandler {
         XlsxColumnNumber startColumnNumber = horizontalFor.startColumnIndex().isEmpty()
                 ? baseAddress.columnNumber()
                 : new XlsxColumnNumber(horizontalFor.startColumnIndex());
-        try {
-            for (int i = 0; i < collection.size(); i++) {
+        try (VariableResolver.Iteration collection =
+                     variableResolver.openIteration(horizontalFor.collection().toString())) {
+            int i = 0;
+            while (collection.hasNext()) {
+                Object item = collection.next();
                 XlsxCellAddress currentAddress = baseAddress.with(
                         startRowNumber,
                         new XlsxColumnNumber(startColumnNumber.toLong() + i)
                 );
                 buffer.addressStack().push(currentAddress);
                 buffer.loopContext().put(horizontalFor.index(), i);
-                buffer.loopContext().put(horizontalFor.item(), collection.get(i));
+                buffer.loopContext().put(horizontalFor.item(), item);
                 try {
                     dispatch(horizontalFor.children());
                 } finally {
                     buffer.addressStack().pop();
                 }
+                i++;
             }
         } finally {
             buffer.loopContext().remove(horizontalFor.index());

--- a/src/main/java/io/luchta/forma4j/writer/engine/handler/element/ListHandler.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/handler/element/ListHandler.java
@@ -10,9 +10,9 @@ import io.luchta.forma4j.writer.engine.model.cell.XlsxCell;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxCellAddress;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxColumnNumber;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxRowNumber;
-import io.luchta.forma4j.writer.engine.model.cell.style.XlsxCellType;
 import io.luchta.forma4j.writer.engine.model.cell.value.Text;
-import java.util.List;
+import io.luchta.forma4j.writer.engine.resolver.VariableResolver;
+
 import java.util.Map;
 import java.util.Set;
 
@@ -24,6 +24,7 @@ import java.util.Set;
  *
  * @since 1.1.0
  */
+@SuppressWarnings("unchecked")
 public class ListHandler {
     private BuildBuffer buffer;
 
@@ -55,24 +56,33 @@ public class ListHandler {
         Style detailStyle = listElement.detailStyle();
         Collection collection = listElement.collection();
 
-        header(address(new XlsxRowNumber(rowIndex), new XlsxColumnNumber(columnIndex)), headerStyle, collection);
-        detail(address(new XlsxRowNumber(rowIndex + 1), new XlsxColumnNumber(columnIndex)), detailStyle, collection);
+        try (VariableResolver.Iteration iterator = collection(collection)) {
+            if (!iterator.hasNext()) {
+                return;
+            }
+
+            Object first = iterator.next();
+            if (!(first instanceof Map<?, ?>)) {
+                return;
+            }
+
+            header(address(new XlsxRowNumber(rowIndex), new XlsxColumnNumber(columnIndex)), headerStyle, (Map<String, Object>) first);
+            detail(address(new XlsxRowNumber(rowIndex + 1), new XlsxColumnNumber(columnIndex)), detailStyle, first, iterator);
+        }
     }
 
-    private void header(XlsxCellAddress address, Style style, Collection collection) {
+    private VariableResolver.Iteration collection(Collection collection) {
         Set<String> keySet = buffer.variableResolver().getKeySet();
-        String key = keySet.iterator().next();
+        String key = keySet.isEmpty() ? "" : keySet.iterator().next();
         if (!collection.isEmpty()) {
             key = collection.toString();
         }
-        List<Object> list = buffer.variableResolver().getList(key);
-        if (list.size() == 0 || !(list.get(0) instanceof Map<?, ?>)) {
-            return;
-        }
+        return buffer.variableResolver().openIteration(key);
+    }
 
-        Map<String, Object> map = (Map<String, Object>) list.get(0);
+    private void header(XlsxCellAddress address, Style style, Map<String, Object> map) {
         for (String headerName : map.keySet()) {
-            buffer.accumulator().put(
+            buffer.outputStrategy().writeCell(
                     address,
                     new XlsxCell(
                             address,
@@ -83,36 +93,39 @@ public class ListHandler {
         }
     }
 
-    private void detail(XlsxCellAddress address, Style style, Collection collection) {
-        Set<String> keySet = buffer.variableResolver().getKeySet();
-        String key = keySet.iterator().next();
-        if (!collection.isEmpty()) {
-            key = collection.toString();
-        }
-        List<Object> list = buffer.variableResolver().getList(key);
-        if (list.size() == 0 || !(list.get(0) instanceof Map<?, ?>)) {
-            return;
-        }
-
+    private void detail(
+            XlsxCellAddress address,
+            Style style,
+            Object first,
+            VariableResolver.Iteration iterator
+    ) {
         Long columnIndex = address.columnNumber().toLong();
-        for (Object obj : list) {
+        writeDetail(address, style, first);
+        address = address.rowNumberIncrement().with(new XlsxColumnNumber(columnIndex));
+        while (iterator.hasNext()) {
+            Object obj = iterator.next();
             if (!(obj instanceof Map<?, ?>)) {
                 continue;
             }
-
-            Map<String, Object> line = (Map<String, Object>) obj;
-            for (Object value : line.values()) {
-                buffer.accumulator().put(
-                        address,
-                        new XlsxCell(
-                                address,
-                                new Text(value.toString()),
-                                buffer.styleResolver().get(style, buffer.variableResolver()),
-                                null));
-                address = address.columnNumberIncrement();
-            }
-
+            writeDetail(address, style, obj);
             address = address.rowNumberIncrement().with(new XlsxColumnNumber(columnIndex));
+        }
+    }
+
+    private void writeDetail(XlsxCellAddress address, Style style, Object obj) {
+        if (!(obj instanceof Map<?, ?>)) {
+            return;
+        }
+        Map<String, Object> line = (Map<String, Object>) obj;
+        for (Object value : line.values()) {
+            buffer.outputStrategy().writeCell(
+                    address,
+                    new XlsxCell(
+                            address,
+                            new Text(value.toString()),
+                            buffer.styleResolver().get(style, buffer.variableResolver()),
+                            null));
+            address = address.columnNumberIncrement();
         }
     }
 

--- a/src/main/java/io/luchta/forma4j/writer/engine/handler/element/RowHandler.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/handler/element/RowHandler.java
@@ -12,10 +12,6 @@ import io.luchta.forma4j.writer.engine.model.cell.address.XlsxColumnNumber;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxRowNumber;
 import io.luchta.forma4j.writer.engine.model.row.address.XlsxRowAddress;
 import io.luchta.forma4j.writer.engine.model.row.property.AutoFilterProperty;
-import io.luchta.forma4j.writer.engine.resolver.VariableResolver;
-
-import java.util.List;
-
 /**
  * Rowタグのハンドラクラス
  */
@@ -45,7 +41,7 @@ public class RowHandler {
                     new XlsxRowNumber(row.rowIndex()),
                     new XlsxColumnNumber(row.startColumnIndex().value())
             );
-            buffer.accumulator().putRowProperty(
+            buffer.outputStrategy().writeRowProperty(
                     new XlsxRowAddress(rowAddress.sheetName(), new XlsxRowNumber(row.rowIndex())),
                     AutoFilterProperty.create(row.autoFilter().value()));
         }
@@ -70,12 +66,6 @@ public class RowHandler {
                     break;
                 case HORIZONTAL_FOR:
                     HorizontalFor horizontalFor = (HorizontalFor) element;
-                    VariableResolver variableResolver = buffer.variableResolver();
-                    List<Object> collection = variableResolver.getList(horizontalFor.collection().toString());
-                    if (collection.size() == 0) {
-                        break;
-                    }
-
                     if (!horizontalFor.hasChildren()) {
                         break;
                     }

--- a/src/main/java/io/luchta/forma4j/writer/engine/handler/element/SheetHandler.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/handler/element/SheetHandler.java
@@ -13,8 +13,8 @@ import io.luchta.forma4j.writer.engine.model.cell.address.XlsxCellAddress;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxColumnNumber;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxRowNumber;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxSheetName;
+import io.luchta.forma4j.writer.engine.resolver.VariableResolver;
 
-import java.util.List;
 import java.util.Map;
 
 /**
@@ -45,12 +45,13 @@ public class SheetHandler {
         if (collection.isEmpty()) {
             XlsxSheetName sheetName = new XlsxSheetName(sheet.name());
             XlsxCellAddress address = new XlsxCellAddress(sheetName, XlsxRowNumber.init(), XlsxColumnNumber.init());
-            buffer.accumulator().add(sheetName, autoSizeColumnEnabled);
+            buffer.outputStrategy().startSheet(sheetName, autoSizeColumnEnabled);
             buffer.addressStack().push(address);
             try {
                 dispatch(sheet.children());
             } finally {
                 buffer.addressStack().pop();
+                buffer.outputStrategy().finishSheet(sheetName);
             }
         } else {
             if (sheet.children().size() == 1 && sheet.children().get(0).type() == ElementType.LIST) {
@@ -67,23 +68,30 @@ public class SheetHandler {
      * @param collection
      */
     private void handleCollection(Sheet sheet, Collection collection) {
-        List<Object> list = buffer.variableResolver().getList(collection.toString());
-        for (Object obj : list) {
-            if (obj instanceof Map) {
-                // シートの設定
-                Map<String, Object> map = (Map<String, Object>) obj;
-                XlsxSheetName sheetName = new XlsxSheetName(new Name(map.get("sheetName").toString()));
-                XlsxCellAddress address = new XlsxCellAddress(sheetName, XlsxRowNumber.init(), XlsxColumnNumber.init());
-                buffer.accumulator().add(sheetName, autoSizeColumnEnabled(sheet));
-                buffer.addressStack().push(address);
-                buffer.loopContext().put(new Index(), 0);
-                buffer.loopContext().put(new Item(sheet.item().toString()), map);
-                try {
-                    dispatch(sheet.children());
-                } finally {
-                    buffer.addressStack().pop();
+        try (VariableResolver.Iteration list =
+                     buffer.variableResolver().openIteration(collection.toString())) {
+            while (list.hasNext()) {
+                Object obj = list.next();
+                if (obj instanceof Map) {
+                    // シートの設定
+                    Map<String, Object> map = (Map<String, Object>) obj;
+                    XlsxSheetName sheetName = new XlsxSheetName(new Name(map.get("sheetName").toString()));
+                    XlsxCellAddress address = new XlsxCellAddress(sheetName, XlsxRowNumber.init(), XlsxColumnNumber.init());
+                    buffer.outputStrategy().startSheet(sheetName, autoSizeColumnEnabled(sheet));
+                    buffer.addressStack().push(address);
+                    buffer.loopContext().put(new Index(), 0);
+                    buffer.loopContext().put(new Item(sheet.item().toString()), map);
+                    try {
+                        dispatch(sheet.children());
+                    } finally {
+                        buffer.addressStack().pop();
+                        buffer.outputStrategy().finishSheet(sheetName);
+                    }
                 }
             }
+        } finally {
+            buffer.loopContext().remove(new Index());
+            buffer.loopContext().remove(new Item(sheet.item().toString()));
         }
     }
 
@@ -93,28 +101,31 @@ public class SheetHandler {
      * @param collection
      */
     private void handleCollectionWithListTag(Sheet sheet, Collection collection) {
-        List<Object> list = buffer.variableResolver().getList(collection.toString());
-        for (Object obj : list) {
-            if (obj instanceof Map) {
-                Map<String, Object> sheets = (Map<String, Object>) obj;
-                for (Map.Entry<String, Object> entry : sheets.entrySet()) {
-                    if (!(obj instanceof Map)) {
-                        continue;
-                    }
-
-                    XlsxSheetName sheetName = new XlsxSheetName(new Name(entry.getKey()));
-                    XlsxCellAddress address = new XlsxCellAddress(sheetName, XlsxRowNumber.init(), XlsxColumnNumber.init());
-                    buffer.accumulator().add(sheetName, autoSizeColumnEnabled(sheet));
-                    buffer.addressStack().push(address);
-                    buffer.loopContext().put(new Index(), 0);
-                    buffer.loopContext().put(new Item(sheet.item().toString()), entry.getValue());
-                    try {
-                        dispatch(sheet.children());
-                    } finally {
-                        buffer.addressStack().pop();
+        try (VariableResolver.Iteration list =
+                     buffer.variableResolver().openIteration(collection.toString())) {
+            while (list.hasNext()) {
+                Object obj = list.next();
+                if (obj instanceof Map) {
+                    Map<String, Object> sheets = (Map<String, Object>) obj;
+                    for (Map.Entry<String, Object> entry : sheets.entrySet()) {
+                        XlsxSheetName sheetName = new XlsxSheetName(new Name(entry.getKey()));
+                        XlsxCellAddress address = new XlsxCellAddress(sheetName, XlsxRowNumber.init(), XlsxColumnNumber.init());
+                        buffer.outputStrategy().startSheet(sheetName, autoSizeColumnEnabled(sheet));
+                        buffer.addressStack().push(address);
+                        buffer.loopContext().put(new Index(), 0);
+                        buffer.loopContext().put(new Item(sheet.item().toString()), entry.getValue());
+                        try {
+                            dispatch(sheet.children());
+                        } finally {
+                            buffer.addressStack().pop();
+                            buffer.outputStrategy().finishSheet(sheetName);
+                        }
                     }
                 }
             }
+        } finally {
+            buffer.loopContext().remove(new Index());
+            buffer.loopContext().remove(new Item(sheet.item().toString()));
         }
     }
 

--- a/src/main/java/io/luchta/forma4j/writer/engine/handler/element/VerticalForHandler.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/handler/element/VerticalForHandler.java
@@ -10,8 +10,6 @@ import io.luchta.forma4j.writer.engine.model.cell.address.XlsxColumnNumber;
 import io.luchta.forma4j.writer.engine.model.cell.address.XlsxRowNumber;
 import io.luchta.forma4j.writer.engine.resolver.VariableResolver;
 
-import java.util.List;
-
 /**
  * vertical-forタグのハンドラクラス
  */
@@ -33,24 +31,27 @@ public class VerticalForHandler {
      */
     public void handle(VerticalFor verticalFor) {
         VariableResolver variableResolver = buffer.variableResolver();
-        List<Object> collection = variableResolver.getList(verticalFor.collection().toString());
         XlsxCellAddress baseAddress = buffer.addressStack().peek();
         XlsxRowNumber startRowNumber = new XlsxRowNumber(verticalFor.startRowIndex());
         XlsxColumnNumber startColumnNumber = new XlsxColumnNumber(verticalFor.startColumnIndex());
-        try {
-            for (int i = 0; i < collection.size(); i++) {
+        try (VariableResolver.Iteration collection =
+                     variableResolver.openIteration(verticalFor.collection().toString())) {
+            int i = 0;
+            while (collection.hasNext()) {
+                Object item = collection.next();
                 XlsxCellAddress currentAddress = baseAddress.with(
                         new XlsxRowNumber((long) startRowNumber.toInt() + i),
                         startColumnNumber
                 );
                 buffer.addressStack().push(currentAddress);
                 buffer.loopContext().put(verticalFor.index(), i);
-                buffer.loopContext().put(verticalFor.item(), collection.get(i));
+                buffer.loopContext().put(verticalFor.item(), item);
                 try {
                     dispatch(verticalFor.children());
                 } finally {
                     buffer.addressStack().pop();
                 }
+                i++;
             }
         } finally {
             buffer.loopContext().remove(verticalFor.index());

--- a/src/main/java/io/luchta/forma4j/writer/engine/model/column/property/XlsxColumnProperty.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/model/column/property/XlsxColumnProperty.java
@@ -5,7 +5,7 @@ package io.luchta.forma4j.writer.engine.model.column.property;
  */
 public interface XlsxColumnProperty {
     static XlsxColumnProperty of(String name, String value) {
-        switch(name) {
+        switch(name.toUpperCase()) {
             case WidthProperty.NAME:
                 return new WidthProperty(value);
             default:

--- a/src/main/java/io/luchta/forma4j/writer/engine/model/row/address/XlsxRowAddress.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/model/row/address/XlsxRowAddress.java
@@ -16,6 +16,14 @@ public class XlsxRowAddress {
         this.rowNumber = rowNumber;
     }
 
+    public XlsxSheetName sheetName() {
+        return sheetName;
+    }
+
+    public XlsxRowNumber rowNumber() {
+        return rowNumber;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;

--- a/src/main/java/io/luchta/forma4j/writer/engine/resolver/VariableResolver.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/resolver/VariableResolver.java
@@ -4,7 +4,11 @@ import io.luchta.forma4j.writer.Context;
 import io.luchta.forma4j.writer.engine.buffer.loop.LoopContext;
 import io.luchta.forma4j.writer.engine.model.cell.value.*;
 import io.luchta.forma4j.writer.engine.model.cell.value.Date;
+import io.luchta.forma4j.writer.stream.CloseableIterator;
+import io.luchta.forma4j.writer.stream.SequenceSource;
 
+import java.io.IOException;
+import java.io.UncheckedIOException;
 import java.math.BigDecimal;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -23,6 +27,8 @@ public class VariableResolver {
     private Context context;
     /** ループ処理用のコンテキスト */
     private LoopContext loopContext;
+    /** コレクションを開く処理 */
+    private SequenceOpener sequenceOpener;
 
     /**
      * コンストラクタ
@@ -30,8 +36,17 @@ public class VariableResolver {
      * @param loopContext
      */
     public VariableResolver(Context context, LoopContext loopContext) {
+        this(context, loopContext, VariableResolver::openDirect);
+    }
+
+    public VariableResolver(
+            Context context,
+            LoopContext loopContext,
+            SequenceOpener sequenceOpener
+    ) {
         this.context = context;
         this.loopContext = loopContext;
+        this.sequenceOpener = sequenceOpener;
     }
 
     /**
@@ -58,6 +73,31 @@ public class VariableResolver {
         Object loopContextVar = getValue(key, loopContext);
         if (loopContextVar != null) return (List<Object>) loopContextVar;
         return Collections.emptyList();
+    }
+
+    /**
+     * 変数の値を逐次処理可能な Iterable として取得します。
+     * List を含む従来の Iterable 値もそのまま返します。
+     */
+    @SuppressWarnings("unchecked")
+    public Iterable<Object> getIterable(String key) {
+        Object contextVar = getValue(key, context);
+        if (contextVar instanceof Iterable) return (Iterable<Object>) contextVar;
+        Object loopContextVar = getValue(key, loopContext);
+        if (loopContextVar instanceof Iterable) return (Iterable<Object>) loopContextVar;
+        return Collections.emptyList();
+    }
+
+    /**
+     * コレクションを1回の参照として開きます。
+     * 返されたIterationは必ず閉じてください。
+     */
+    public Iteration openIteration(String key) {
+        Object value = getValue(key, context);
+        if (value == null) {
+            value = getValue(key, loopContext);
+        }
+        return new Iteration(sequenceOpener.open(key, value));
     }
 
     /**
@@ -158,5 +198,96 @@ public class VariableResolver {
         } catch (Exception ignored) {}
 
         return new Text(String.valueOf(obj));
+    }
+
+    @SuppressWarnings("unchecked")
+    private static CloseableIterator<Object> openDirect(String name, Object value) {
+        try {
+            if (value instanceof SequenceSource<?>) {
+                return (CloseableIterator<Object>) ((SequenceSource<?>) value).open();
+            }
+            if (value instanceof Iterable<?>) {
+                return closeable((Iterator<Object>) ((Iterable<?>) value).iterator());
+            }
+            return closeable(Collections.emptyIterator());
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    private static CloseableIterator<Object> closeable(Iterator<Object> iterator) {
+        if (iterator instanceof CloseableIterator<?>) {
+            return (CloseableIterator<Object>) iterator;
+        }
+        return new CloseableIterator<Object>() {
+            @Override
+            public boolean hasNext() {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public Object next() {
+                return iterator.next();
+            }
+
+            @Override
+            public void remove() {
+                iterator.remove();
+            }
+
+            @Override
+            public void close() throws IOException {
+                if (!(iterator instanceof AutoCloseable)) {
+                    return;
+                }
+                try {
+                    ((AutoCloseable) iterator).close();
+                } catch (IOException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new IOException("Iterator のクローズに失敗しました。", e);
+                }
+            }
+        };
+    }
+
+    @FunctionalInterface
+    public interface SequenceOpener {
+        CloseableIterator<Object> open(String name, Object value);
+    }
+
+    /**
+     * close時のIOExceptionをUncheckedIOExceptionとして伝播する反復スコープです。
+     */
+    public static final class Iteration implements Iterator<Object>, AutoCloseable {
+        private final CloseableIterator<Object> delegate;
+
+        private Iteration(CloseableIterator<Object> delegate) {
+            this.delegate = delegate;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return delegate.hasNext();
+        }
+
+        @Override
+        public Object next() {
+            return delegate.next();
+        }
+
+        @Override
+        public void remove() {
+            delegate.remove();
+        }
+
+        @Override
+        public void close() {
+            try {
+                delegate.close();
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
     }
 }

--- a/src/main/java/io/luchta/forma4j/writer/engine/strategy/AccumulatingOutputStrategy.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/strategy/AccumulatingOutputStrategy.java
@@ -1,0 +1,56 @@
+package io.luchta.forma4j.writer.engine.strategy;
+
+import io.luchta.forma4j.writer.engine.buffer.accumulater.BuildAccumulator;
+import io.luchta.forma4j.writer.engine.model.cell.XlsxCell;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxCellAddress;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxSheetName;
+import io.luchta.forma4j.writer.engine.model.column.XlsxColumnAddress;
+import io.luchta.forma4j.writer.engine.model.column.property.XlsxColumnProperty;
+import io.luchta.forma4j.writer.engine.model.row.address.XlsxRowAddress;
+import io.luchta.forma4j.writer.engine.model.row.property.XlsxRowProperty;
+import io.luchta.forma4j.writer.processor.poi.WorkbookBuilder;
+import org.apache.poi.ss.usermodel.Workbook;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/** 既存の DOM 用データを蓄積する出力戦略です。 */
+public class AccumulatingOutputStrategy implements XlsxOutputStrategy {
+    private final BuildAccumulator accumulator = new BuildAccumulator();
+
+    public BuildAccumulator accumulator() {
+        return accumulator;
+    }
+
+    @Override
+    public void startSheet(XlsxSheetName sheetName, Boolean autoSizeColumnEnabled) {
+        accumulator.add(sheetName, autoSizeColumnEnabled);
+    }
+
+    @Override
+    public void finishSheet(XlsxSheetName sheetName) {
+        // DOM 出力ではシート全体を最後に組み立てるため処理は不要です。
+    }
+
+    @Override
+    public void writeCell(XlsxCellAddress address, XlsxCell cell) {
+        accumulator.put(address, cell);
+    }
+
+    @Override
+    public void writeRowProperty(XlsxRowAddress address, XlsxRowProperty property) {
+        accumulator.putRowProperty(address, property);
+    }
+
+    @Override
+    public void writeColumnProperty(XlsxColumnAddress address, XlsxColumnProperty property) {
+        accumulator.putColumnProperties(address, property);
+    }
+
+    @Override
+    public void write(OutputStream outputStream) throws IOException {
+        try (Workbook workbook = new WorkbookBuilder(accumulator).build()) {
+            workbook.write(outputStream);
+        }
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/engine/strategy/StreamingOutputStrategy.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/strategy/StreamingOutputStrategy.java
@@ -1,0 +1,21 @@
+package io.luchta.forma4j.writer.engine.strategy;
+
+import io.luchta.forma4j.writer.engine.strategy.ooxml.AbstractOoxmlOutputStrategy;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/**
+ * セル命令を一時ファイルへ退避し、OOXMLパッケージを逐次生成する出力戦略です。
+ * 列幅の自動調整は行わず、明示された列幅だけを出力します。
+ */
+public class StreamingOutputStrategy extends AbstractOoxmlOutputStrategy {
+    public StreamingOutputStrategy() {
+        super();
+    }
+
+    @Override
+    protected void writePackage(OutputStream outputStream) throws IOException {
+        writeBlankOoxmlPackage(outputStream);
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/engine/strategy/XlsxOutputStrategy.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/strategy/XlsxOutputStrategy.java
@@ -1,0 +1,27 @@
+package io.luchta.forma4j.writer.engine.strategy;
+
+import io.luchta.forma4j.writer.engine.model.cell.XlsxCell;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxCellAddress;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxSheetName;
+import io.luchta.forma4j.writer.engine.model.column.XlsxColumnAddress;
+import io.luchta.forma4j.writer.engine.model.column.property.XlsxColumnProperty;
+import io.luchta.forma4j.writer.engine.model.row.address.XlsxRowAddress;
+import io.luchta.forma4j.writer.engine.model.row.property.XlsxRowProperty;
+
+import java.io.IOException;
+import java.io.OutputStream;
+
+/** Excel 出力先を切り替えるための戦略です。 */
+public interface XlsxOutputStrategy {
+    void startSheet(XlsxSheetName sheetName, Boolean autoSizeColumnEnabled);
+
+    void finishSheet(XlsxSheetName sheetName);
+
+    void writeCell(XlsxCellAddress address, XlsxCell cell);
+
+    void writeRowProperty(XlsxRowAddress address, XlsxRowProperty property);
+
+    void writeColumnProperty(XlsxColumnAddress address, XlsxColumnProperty property);
+
+    void write(OutputStream outputStream) throws IOException;
+}

--- a/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/AbstractOoxmlOutputStrategy.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/AbstractOoxmlOutputStrategy.java
@@ -1,0 +1,194 @@
+package io.luchta.forma4j.writer.engine.strategy.ooxml;
+
+import io.luchta.forma4j.writer.engine.model.cell.XlsxCell;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxCellAddress;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxSheetName;
+import io.luchta.forma4j.writer.engine.model.column.XlsxColumnAddress;
+import io.luchta.forma4j.writer.engine.model.column.property.WidthProperty;
+import io.luchta.forma4j.writer.engine.model.column.property.XlsxColumnProperty;
+import io.luchta.forma4j.writer.engine.model.row.address.XlsxRowAddress;
+import io.luchta.forma4j.writer.engine.model.row.property.AutoFilterProperty;
+import io.luchta.forma4j.writer.engine.model.row.property.XlsxRowProperty;
+import io.luchta.forma4j.writer.engine.strategy.XlsxOutputStrategy;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+public abstract class AbstractOoxmlOutputStrategy implements XlsxOutputStrategy, AutoCloseable {
+    protected final Map<String, SheetState> sheets = new LinkedHashMap<>();
+    protected final OoxmlStyleRegistry styles = new OoxmlStyleRegistry();
+    protected final Path temporaryDirectory;
+    private long sequence;
+    private boolean formulas;
+    private boolean closed;
+
+    protected AbstractOoxmlOutputStrategy() {
+        try {
+            temporaryDirectory = Files.createTempDirectory("forma4j-ooxml-");
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public final void startSheet(XlsxSheetName sheetName, Boolean autoSizeColumnEnabled) {
+        sheet(sheetName.toString());
+        // OOXML の逐次出力では全セルを保持しないため autoSizeColumn は意図的に無効です。
+    }
+
+    @Override
+    public final void finishSheet(XlsxSheetName sheetName) {
+        // 最終パッケージ生成時にシートを確定します。
+    }
+
+    @Override
+    public final void writeCell(XlsxCellAddress address, XlsxCell cell) {
+        SheetState sheet = sheet(address.sheetName().toString());
+        int row = address.rowNumber().toInt();
+        int column = cell.columnNumber().toInt();
+        int styleToken = styles.register(cell.style());
+        CellCommand command = CellCommand.from(
+                row,
+                column,
+                sequence++,
+                cell,
+                styleToken
+        );
+        if (command.type == CellCommand.ValueType.FORMULA) {
+            formulas = true;
+        }
+        try {
+            sheet.commands.append(command);
+            sheet.appendedCell();
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+        sheet.includeInAutoFilter(row, column);
+    }
+
+    @Override
+    public final void writeRowProperty(XlsxRowAddress address, XlsxRowProperty property) {
+        if (property instanceof AutoFilterProperty
+                && ((AutoFilterProperty) property).booleanValue()) {
+            sheet(address.sheetName().toString()).markAutoFilter(address.rowNumber().toInt());
+        }
+    }
+
+    @Override
+    public final void writeColumnProperty(
+            XlsxColumnAddress address,
+            XlsxColumnProperty property
+    ) {
+        if (property instanceof WidthProperty) {
+            sheet(address.sheetName().toString()).columnWidths.put(
+                    address.columnNumber().toInt(),
+                    ((WidthProperty) property).intValue()
+            );
+        }
+    }
+
+    @Override
+    public final void write(OutputStream outputStream) throws IOException {
+        try {
+            writePackage(outputStream);
+        } catch (CellCommandStore.CellCommandReadException e) {
+            throw e.ioCause();
+        } finally {
+            close();
+        }
+    }
+
+    protected abstract void writePackage(OutputStream outputStream) throws IOException;
+
+    protected final boolean hasFormulas() {
+        return formulas;
+    }
+
+    protected final void writeBlankOoxmlPackage(OutputStream outputStream) throws IOException {
+        OoxmlStyleRegistry.PreparedStyles preparedStyles = styles.prepareBlank();
+        new BlankOoxmlPackageWriter().write(
+                outputStream,
+                sheets,
+                preparedStyles,
+                formulas
+        );
+    }
+
+    protected final void writeTemplateOoxmlPackage(
+            Path template,
+            OutputStream outputStream
+    ) throws IOException {
+        new TemplateOoxmlPackageWriter(template).write(
+                outputStream,
+                sheets,
+                styles,
+                formulas
+        );
+    }
+
+    protected final SheetState sheet(String name) {
+        SheetState existing = sheets.get(name);
+        if (existing != null) {
+            return existing;
+        }
+        try {
+            SheetState created = new SheetState(name, temporaryDirectory, sheets.size());
+            sheets.put(name, created);
+            return created;
+        } catch (IOException e) {
+            throw new UncheckedIOException(e);
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        IOException failure = null;
+        for (SheetState sheet : sheets.values()) {
+            try {
+                sheet.commands.close();
+            } catch (IOException e) {
+                failure = append(failure, e);
+            }
+        }
+        try {
+            styles.close();
+        } catch (IOException e) {
+            failure = append(failure, e);
+        }
+        try (Stream<Path> paths = Files.walk(temporaryDirectory)) {
+            paths.sorted(Comparator.reverseOrder()).forEach(path -> {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException e) {
+                    throw new UncheckedIOException(e);
+                }
+            });
+        } catch (UncheckedIOException e) {
+            failure = append(failure, e.getCause());
+        } catch (IOException e) {
+            failure = append(failure, e);
+        }
+        if (failure != null) {
+            throw failure;
+        }
+    }
+
+    private static IOException append(IOException current, IOException addition) {
+        if (current == null) {
+            return addition;
+        }
+        current.addSuppressed(addition);
+        return current;
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/BlankOoxmlPackageWriter.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/BlankOoxmlPackageWriter.java
@@ -1,0 +1,182 @@
+package io.luchta.forma4j.writer.engine.strategy.ooxml;
+
+import org.apache.poi.ss.util.WorkbookUtil;
+
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+final class BlankOoxmlPackageWriter {
+    private static final String RELATIONSHIPS_NAMESPACE =
+            "http://schemas.openxmlformats.org/package/2006/relationships";
+    private static final String OFFICE_RELATIONSHIPS_NAMESPACE =
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+    private static final String CONTENT_TYPES_NAMESPACE =
+            "http://schemas.openxmlformats.org/package/2006/content-types";
+
+    private final WorksheetXmlWriter worksheetWriter = new WorksheetXmlWriter();
+    private final XMLOutputFactory xmlOutputFactory = XMLOutputFactory.newFactory();
+
+    void write(
+            OutputStream output,
+            Map<String, SheetState> sheets,
+            OoxmlStyleRegistry.PreparedStyles styles,
+            boolean formulas
+    ) throws IOException {
+        for (String sheetName : sheets.keySet()) {
+            WorkbookUtil.validateSheetName(sheetName);
+        }
+        ZipOutputStream zip = new ZipOutputStream(output);
+        writeContentTypes(zip, sheets.size());
+        writeRootRelationships(zip);
+        writeWorkbook(zip, sheets, formulas);
+        writeWorkbookRelationships(zip, sheets.size());
+        writeStyles(zip, styles);
+
+        int index = 1;
+        for (SheetState sheet : sheets.values()) {
+            putEntry(zip, "xl/worksheets/sheet" + index++ + ".xml");
+            worksheetWriter.writeBlank(zip, sheet, styles, false);
+            zip.closeEntry();
+        }
+        zip.finish();
+        zip.flush();
+    }
+
+    private void writeContentTypes(ZipOutputStream zip, int sheetCount) throws IOException {
+        putEntry(zip, "[Content_Types].xml");
+        writeXml(zip, writer -> {
+            writer.writeStartElement("Types");
+            writer.writeDefaultNamespace(CONTENT_TYPES_NAMESPACE);
+            empty(writer, "Default", "Extension", "rels", "ContentType",
+                    "application/vnd.openxmlformats-package.relationships+xml");
+            empty(writer, "Default", "Extension", "xml", "ContentType", "application/xml");
+            empty(writer, "Override", "PartName", "/xl/workbook.xml", "ContentType",
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet.main+xml");
+            empty(writer, "Override", "PartName", "/xl/styles.xml", "ContentType",
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml");
+            for (int index = 1; index <= sheetCount; index++) {
+                empty(writer, "Override",
+                        "PartName", "/xl/worksheets/sheet" + index + ".xml",
+                        "ContentType",
+                        "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml");
+            }
+            writer.writeEndElement();
+        });
+        zip.closeEntry();
+    }
+
+    private void writeRootRelationships(ZipOutputStream zip) throws IOException {
+        putEntry(zip, "_rels/.rels");
+        writeXml(zip, writer -> {
+            writer.writeStartElement("Relationships");
+            writer.writeDefaultNamespace(RELATIONSHIPS_NAMESPACE);
+            empty(writer, "Relationship",
+                    "Id", "rId1",
+                    "Type", OFFICE_RELATIONSHIPS_NAMESPACE + "/officeDocument",
+                    "Target", "xl/workbook.xml");
+            writer.writeEndElement();
+        });
+        zip.closeEntry();
+    }
+
+    private void writeWorkbook(
+            ZipOutputStream zip,
+            Map<String, SheetState> sheets,
+            boolean formulas
+    ) throws IOException {
+        putEntry(zip, "xl/workbook.xml");
+        writeXml(zip, writer -> {
+            writer.writeStartElement("workbook");
+            writer.writeDefaultNamespace(WorksheetXmlWriter.SPREADSHEET_NAMESPACE);
+            writer.writeNamespace("r", OFFICE_RELATIONSHIPS_NAMESPACE);
+            writer.writeStartElement("sheets");
+            int index = 1;
+            for (String name : sheets.keySet()) {
+                writer.writeEmptyElement("sheet");
+                writer.writeAttribute("name", name);
+                writer.writeAttribute("sheetId", Integer.toString(index));
+                writer.writeAttribute(
+                        "r",
+                        OFFICE_RELATIONSHIPS_NAMESPACE,
+                        "id",
+                        "rId" + (index + 1)
+                );
+                index++;
+            }
+            writer.writeEndElement();
+            if (formulas) {
+                writer.writeEmptyElement("calcPr");
+                writer.writeAttribute("calcMode", "auto");
+                writer.writeAttribute("fullCalcOnLoad", "1");
+                writer.writeAttribute("forceFullCalc", "1");
+            }
+            writer.writeEndElement();
+        });
+        zip.closeEntry();
+    }
+
+    private void writeWorkbookRelationships(ZipOutputStream zip, int sheetCount)
+            throws IOException {
+        putEntry(zip, "xl/_rels/workbook.xml.rels");
+        writeXml(zip, writer -> {
+            writer.writeStartElement("Relationships");
+            writer.writeDefaultNamespace(RELATIONSHIPS_NAMESPACE);
+            empty(writer, "Relationship",
+                    "Id", "rId1",
+                    "Type", OFFICE_RELATIONSHIPS_NAMESPACE + "/styles",
+                    "Target", "styles.xml");
+            for (int index = 1; index <= sheetCount; index++) {
+                empty(writer, "Relationship",
+                        "Id", "rId" + (index + 1),
+                        "Type", OFFICE_RELATIONSHIPS_NAMESPACE + "/worksheet",
+                        "Target", "worksheets/sheet" + index + ".xml");
+            }
+            writer.writeEndElement();
+        });
+        zip.closeEntry();
+    }
+
+    private void writeStyles(
+            ZipOutputStream zip,
+            OoxmlStyleRegistry.PreparedStyles styles
+    ) throws IOException {
+        putEntry(zip, "xl/styles.xml");
+        styles.write(zip);
+        zip.closeEntry();
+    }
+
+    private void writeXml(OutputStream output, XmlBody body) throws IOException {
+        try {
+            XMLStreamWriter writer = xmlOutputFactory.createXMLStreamWriter(output, "UTF-8");
+            writer.writeStartDocument("UTF-8", "1.0");
+            body.write(writer);
+            writer.writeEndDocument();
+            writer.flush();
+        } catch (XMLStreamException e) {
+            throw new IOException("OOXMLパーツの生成に失敗しました。", e);
+        }
+    }
+
+    private void empty(XMLStreamWriter writer, String element, String... attributes)
+            throws XMLStreamException {
+        writer.writeEmptyElement(element);
+        for (int index = 0; index < attributes.length; index += 2) {
+            writer.writeAttribute(attributes[index], attributes[index + 1]);
+        }
+    }
+
+    private void putEntry(ZipOutputStream zip, String name) throws IOException {
+        zip.putNextEntry(new ZipEntry(name));
+    }
+
+    @FunctionalInterface
+    private interface XmlBody {
+        void write(XMLStreamWriter writer) throws XMLStreamException;
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/CellCommand.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/CellCommand.java
@@ -1,0 +1,155 @@
+package io.luchta.forma4j.writer.engine.strategy.ooxml;
+
+import io.luchta.forma4j.writer.engine.model.cell.XlsxCell;
+
+import java.io.DataInput;
+import java.io.DataOutput;
+import java.io.EOFException;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+
+final class CellCommand implements Comparable<CellCommand> {
+    enum ValueType {
+        TEXT,
+        BOOLEAN,
+        NUMERIC,
+        DATE,
+        DATETIME,
+        FORMULA
+    }
+
+    final int row;
+    final int column;
+    final long sequence;
+    final ValueType type;
+    final int styleToken;
+    final boolean emptyStyle;
+    final String value;
+
+    CellCommand(
+            int row,
+            int column,
+            long sequence,
+            ValueType type,
+            int styleToken,
+            boolean emptyStyle,
+            String value
+    ) {
+        this.row = row;
+        this.column = column;
+        this.sequence = sequence;
+        this.type = type;
+        this.styleToken = styleToken;
+        this.emptyStyle = emptyStyle;
+        this.value = value;
+    }
+
+    static CellCommand from(
+            int row,
+            int column,
+            long sequence,
+            XlsxCell cell,
+            int styleToken
+    ) {
+        boolean emptyStyle = cell.style() == null || cell.style().isEmpty();
+        try {
+            if (cell.isFormula()) {
+                return new CellCommand(
+                        row, column, sequence, ValueType.FORMULA, styleToken, emptyStyle,
+                        cell.toFormula().substring(1)
+                );
+            }
+            if (cell.isBoolean()) {
+                return new CellCommand(
+                        row, column, sequence, ValueType.BOOLEAN, styleToken, emptyStyle,
+                        cell.toBoolean() ? "1" : "0"
+                );
+            }
+            if (cell.isDate()) {
+                return new CellCommand(
+                        row, column, sequence, ValueType.DATE, styleToken, emptyStyle,
+                        cell.toDate().toString()
+                );
+            }
+            if (cell.isDateTime()) {
+                return new CellCommand(
+                        row, column, sequence, ValueType.DATETIME, styleToken, emptyStyle,
+                        cell.toDateTime().toString()
+                );
+            }
+            if (cell.isNumeric()) {
+                return new CellCommand(
+                        row, column, sequence, ValueType.NUMERIC, styleToken, emptyStyle,
+                        Double.toString(cell.toNumeric())
+                );
+            }
+            return new CellCommand(
+                    row, column, sequence, ValueType.TEXT, styleToken, emptyStyle,
+                    cell.isEmpty() ? "" : cell.toText()
+            );
+        } catch (Exception ignored) {
+            return new CellCommand(
+                    row, column, sequence, ValueType.TEXT, styleToken, emptyStyle,
+                    cell.isEmpty() ? "" : cell.toText()
+            );
+        }
+    }
+
+    void write(DataOutput output) throws IOException {
+        output.writeInt(row);
+        output.writeInt(column);
+        output.writeLong(sequence);
+        output.writeByte(type.ordinal());
+        output.writeInt(styleToken);
+        output.writeBoolean(emptyStyle);
+        byte[] bytes = value.getBytes(StandardCharsets.UTF_8);
+        output.writeInt(bytes.length);
+        output.write(bytes);
+    }
+
+    static CellCommand read(DataInput input) throws IOException {
+        final int row;
+        try {
+            row = input.readInt();
+        } catch (EOFException e) {
+            return null;
+        }
+        int column = input.readInt();
+        long sequence = input.readLong();
+        int type = input.readUnsignedByte();
+        int styleToken = input.readInt();
+        boolean emptyStyle = input.readBoolean();
+        int length = input.readInt();
+        if (length < 0) {
+            throw new IOException("セル命令の文字列長が不正です: " + length);
+        }
+        byte[] bytes = new byte[length];
+        input.readFully(bytes);
+        return new CellCommand(
+                row,
+                column,
+                sequence,
+                ValueType.values()[type],
+                styleToken,
+                emptyStyle,
+                new String(bytes, StandardCharsets.UTF_8)
+        );
+    }
+
+    boolean sameAddress(CellCommand other) {
+        return row == other.row && column == other.column;
+    }
+
+    @Override
+    public int compareTo(CellCommand other) {
+        int compared = Integer.compare(row, other.row);
+        if (compared != 0) {
+            return compared;
+        }
+        compared = Integer.compare(column, other.column);
+        if (compared != 0) {
+            return compared;
+        }
+        return Long.compare(sequence, other.sequence);
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/CellCommandStore.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/CellCommandStore.java
@@ -1,0 +1,272 @@
+package io.luchta.forma4j.writer.engine.strategy.ooxml;
+
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.Closeable;
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.NoSuchElementException;
+import java.util.PriorityQueue;
+
+final class CellCommandStore implements Closeable {
+    private static final int SORT_CHUNK_SIZE = 4096;
+    private static final int MERGE_FAN_IN = 64;
+
+    private final Path directory;
+    private final Path spool;
+    private DataOutputStream output;
+    private boolean sealed;
+
+    CellCommandStore(Path directory, int number) throws IOException {
+        this.directory = directory;
+        this.spool = directory.resolve("sheet-" + number + ".commands");
+        this.output = new DataOutputStream(new BufferedOutputStream(Files.newOutputStream(spool)));
+    }
+
+    void append(CellCommand command) throws IOException {
+        if (sealed) {
+            throw new IllegalStateException("セル命令ストアは既に確定されています。");
+        }
+        command.write(output);
+    }
+
+    SortedIterator sortedIterator() throws IOException {
+        seal();
+        List<Path> chunks = compactChunks(createSortedChunks());
+        return new SortedIterator(chunks);
+    }
+
+    private void seal() throws IOException {
+        if (sealed) {
+            return;
+        }
+        sealed = true;
+        output.close();
+        output = null;
+    }
+
+    private List<Path> createSortedChunks() throws IOException {
+        List<Path> chunks = new ArrayList<>();
+        try (DataInputStream input = new DataInputStream(
+                new BufferedInputStream(Files.newInputStream(spool)))) {
+            int chunkNumber = 0;
+            while (true) {
+                List<CellCommand> commands = new ArrayList<>(SORT_CHUNK_SIZE);
+                while (commands.size() < SORT_CHUNK_SIZE) {
+                    CellCommand command = CellCommand.read(input);
+                    if (command == null) {
+                        break;
+                    }
+                    commands.add(command);
+                }
+                if (commands.isEmpty()) {
+                    break;
+                }
+                Collections.sort(commands);
+                Path chunk = directory.resolve(
+                        spool.getFileName().toString() + ".sorted-" + chunkNumber++
+                );
+                try (DataOutputStream chunkOutput = new DataOutputStream(
+                        new BufferedOutputStream(Files.newOutputStream(chunk)))) {
+                    for (CellCommand command : commands) {
+                        command.write(chunkOutput);
+                    }
+                }
+                chunks.add(chunk);
+                if (commands.size() < SORT_CHUNK_SIZE) {
+                    break;
+                }
+            }
+        }
+        return chunks;
+    }
+
+    private List<Path> compactChunks(List<Path> chunks) throws IOException {
+        int pass = 0;
+        List<Path> current = chunks;
+        while (current.size() > MERGE_FAN_IN) {
+            List<Path> merged = new ArrayList<>();
+            for (int offset = 0; offset < current.size(); offset += MERGE_FAN_IN) {
+                int end = Math.min(offset + MERGE_FAN_IN, current.size());
+                List<Path> group = new ArrayList<>(current.subList(offset, end));
+                Path result = directory.resolve(
+                        spool.getFileName().toString()
+                                + ".merge-"
+                                + pass
+                                + "-"
+                                + merged.size()
+                );
+                try (SortedIterator iterator = new SortedIterator(group);
+                     DataOutputStream output = new DataOutputStream(
+                             new BufferedOutputStream(Files.newOutputStream(result)))) {
+                    while (iterator.hasNext()) {
+                        iterator.next().write(output);
+                    }
+                }
+                merged.add(result);
+            }
+            current = merged;
+            pass++;
+        }
+        return current;
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (output != null) {
+            output.close();
+            output = null;
+        }
+    }
+
+    static final class SortedIterator implements Iterator<CellCommand>, Closeable {
+        private final List<ChunkReader> readers = new ArrayList<>();
+        private final PriorityQueue<ChunkReader> queue = new PriorityQueue<>(
+                (left, right) -> left.current.compareTo(right.current)
+        );
+        private CellCommand buffered;
+        private CellCommand next;
+        private boolean prepared;
+
+        SortedIterator(List<Path> chunks) throws IOException {
+            try {
+                for (Path chunk : chunks) {
+                    ChunkReader reader = new ChunkReader(chunk);
+                    readers.add(reader);
+                    if (reader.current != null) {
+                        queue.add(reader);
+                    }
+                }
+            } catch (IOException e) {
+                close();
+                throw e;
+            }
+        }
+
+        @Override
+        public boolean hasNext() {
+            prepare();
+            return next != null;
+        }
+
+        @Override
+        public CellCommand next() {
+            prepare();
+            if (next == null) {
+                throw new NoSuchElementException();
+            }
+            CellCommand result = next;
+            prepared = false;
+            next = null;
+            return result;
+        }
+
+        private void prepare() {
+            if (prepared) {
+                return;
+            }
+            prepared = true;
+            CellCommand selected = takeRaw();
+            if (selected == null) {
+                next = null;
+                return;
+            }
+            while (true) {
+                CellCommand candidate = takeRaw();
+                if (candidate == null) {
+                    buffered = null;
+                    break;
+                }
+                if (!selected.sameAddress(candidate)) {
+                    buffered = candidate;
+                    break;
+                }
+                selected = candidate;
+            }
+            next = selected;
+        }
+
+        private CellCommand takeRaw() {
+            if (buffered != null) {
+                CellCommand result = buffered;
+                buffered = null;
+                return result;
+            }
+            ChunkReader reader = queue.poll();
+            if (reader == null) {
+                return null;
+            }
+            CellCommand result = reader.current;
+            try {
+                reader.advance();
+            } catch (IOException e) {
+                throw new CellCommandReadException(e);
+            }
+            if (reader.current != null) {
+                queue.add(reader);
+            }
+            return result;
+        }
+
+        @Override
+        public void close() throws IOException {
+            IOException failure = null;
+            for (ChunkReader reader : readers) {
+                try {
+                    reader.close();
+                } catch (IOException e) {
+                    if (failure == null) {
+                        failure = e;
+                    } else {
+                        failure.addSuppressed(e);
+                    }
+                }
+            }
+            if (failure != null) {
+                throw failure;
+            }
+        }
+    }
+
+    private static final class ChunkReader implements Closeable {
+        private final Path path;
+        private final DataInputStream input;
+        private CellCommand current;
+
+        private ChunkReader(Path path) throws IOException {
+            this.path = path;
+            input = new DataInputStream(new BufferedInputStream(Files.newInputStream(path)));
+            advance();
+        }
+
+        private void advance() throws IOException {
+            current = CellCommand.read(input);
+        }
+
+        @Override
+        public void close() throws IOException {
+            try {
+                input.close();
+            } finally {
+                Files.deleteIfExists(path);
+            }
+        }
+    }
+
+    static final class CellCommandReadException extends RuntimeException {
+        private CellCommandReadException(IOException cause) {
+            super(cause);
+        }
+
+        IOException ioCause() {
+            return (IOException) getCause();
+        }
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/CellReferences.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/CellReferences.java
@@ -1,0 +1,41 @@
+package io.luchta.forma4j.writer.engine.strategy.ooxml;
+
+final class CellReferences {
+    private CellReferences() {
+    }
+
+    static String cell(int row, int column) {
+        return column(column) + (row + 1);
+    }
+
+    static String column(int column) {
+        if (column < 0) {
+            throw new IllegalArgumentException("列番号は0以上である必要があります: " + column);
+        }
+        StringBuilder result = new StringBuilder();
+        int value = column + 1;
+        while (value > 0) {
+            int remainder = (value - 1) % 26;
+            result.append((char) ('A' + remainder));
+            value = (value - 1) / 26;
+        }
+        return result.reverse().toString();
+    }
+
+    static int columnIndex(String reference) {
+        int value = 0;
+        int index = 0;
+        while (index < reference.length()) {
+            char current = reference.charAt(index);
+            if (current >= 'a' && current <= 'z') {
+                current = (char) (current - ('a' - 'A'));
+            }
+            if (current < 'A' || current > 'Z') {
+                break;
+            }
+            value = value * 26 + (current - 'A' + 1);
+            index++;
+        }
+        return value - 1;
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/OoxmlStyleRegistry.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/OoxmlStyleRegistry.java
@@ -1,0 +1,93 @@
+package io.luchta.forma4j.writer.engine.strategy.ooxml;
+
+import io.luchta.forma4j.writer.engine.model.cell.style.XlsxCellStyle;
+import io.luchta.forma4j.writer.processor.poi.CellStyleBuilder;
+import org.apache.poi.ss.usermodel.CellStyle;
+import org.apache.poi.xssf.model.StylesTable;
+import org.apache.poi.xssf.usermodel.XSSFCellStyle;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+final class OoxmlStyleRegistry implements Closeable {
+    private final XSSFWorkbook sourceWorkbook = new XSSFWorkbook();
+    private final Map<XlsxCellStyle, Integer> tokens = new HashMap<>();
+    private final Map<Integer, XSSFCellStyle> sourceStyles = new LinkedHashMap<>();
+    private final Map<Integer, Integer> sourceStyleIds = new HashMap<>();
+    private int nextToken;
+
+    int register(XlsxCellStyle style) {
+        XlsxCellStyle effectiveStyle = style == null ? new XlsxCellStyle() : style;
+        Integer existing = tokens.get(effectiveStyle);
+        if (existing != null) {
+            return existing;
+        }
+        CellStyle built = CellStyleBuilder.of(effectiveStyle, sourceWorkbook).build();
+        int token = nextToken++;
+        tokens.put(effectiveStyle, token);
+        sourceStyles.put(token, (XSSFCellStyle) built);
+        sourceStyleIds.put(
+                token,
+                sourceWorkbook.getStylesSource().getNumCellStyles() - 1
+        );
+        return token;
+    }
+
+    boolean hasCustomStyles() {
+        return !sourceStyles.isEmpty();
+    }
+
+    PreparedStyles prepareBlank() {
+        Map<Integer, Integer> mapping = new HashMap<>();
+        for (Map.Entry<Integer, XSSFCellStyle> entry : sourceStyles.entrySet()) {
+            mapping.put(entry.getKey(), sourceStyleIds.get(entry.getKey()));
+        }
+        return new PreparedStyles(sourceWorkbook.getStylesSource(), mapping);
+    }
+
+    PreparedStyles prepareTemplate(InputStream existingStyles) throws IOException {
+        StylesTable target = existingStyles == null
+                ? new StylesTable()
+                : new StylesTable(existingStyles);
+        Map<Integer, Integer> mapping = new HashMap<>();
+        for (Map.Entry<Integer, XSSFCellStyle> entry : sourceStyles.entrySet()) {
+            XSSFCellStyle targetStyle = target.createCellStyle();
+            targetStyle.cloneStyleFrom(entry.getValue());
+            mapping.put(entry.getKey(), target.getNumCellStyles() - 1);
+        }
+        return new PreparedStyles(target, mapping);
+    }
+
+    @Override
+    public void close() throws IOException {
+        sourceWorkbook.close();
+    }
+
+    static final class PreparedStyles {
+        private final StylesTable styles;
+        private final Map<Integer, Integer> styleIds;
+
+        private PreparedStyles(StylesTable styles, Map<Integer, Integer> styleIds) {
+            this.styles = styles;
+            this.styleIds = styleIds;
+        }
+
+        int styleId(int token) {
+            Integer id = styleIds.get(token);
+            if (id == null) {
+                throw new IllegalStateException("未登録のスタイルトークンです: " + token);
+            }
+            return id;
+        }
+
+        void write(OutputStream output) throws IOException {
+            styles.writeTo(output);
+        }
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/SheetState.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/SheetState.java
@@ -1,0 +1,65 @@
+package io.luchta.forma4j.writer.engine.strategy.ooxml;
+
+import java.io.IOException;
+import java.nio.file.Path;
+import java.util.Map;
+import java.util.TreeMap;
+
+final class SheetState {
+    final String name;
+    final CellCommandStore commands;
+    final Map<Integer, Integer> columnWidths = new TreeMap<>();
+    private AutoFilterRange autoFilter;
+    private long cellCount;
+
+    SheetState(String name, Path directory, int number) throws IOException {
+        this.name = name;
+        commands = new CellCommandStore(directory, number);
+    }
+
+    void markAutoFilter(int row) {
+        autoFilter = new AutoFilterRange(row);
+    }
+
+    void appendedCell() {
+        cellCount++;
+    }
+
+    boolean hasChanges() {
+        return cellCount > 0 || !columnWidths.isEmpty() || autoFilter != null;
+    }
+
+    void includeInAutoFilter(int row, int column) {
+        if (autoFilter != null && autoFilter.row == row) {
+            autoFilter.include(column);
+        }
+    }
+
+    String autoFilterReference() {
+        if (autoFilter == null || autoFilter.firstColumn == null) {
+            return null;
+        }
+        return CellReferences.cell(autoFilter.row, autoFilter.firstColumn)
+                + ":"
+                + CellReferences.cell(autoFilter.row, autoFilter.lastColumn);
+    }
+
+    private static final class AutoFilterRange {
+        private final int row;
+        private Integer firstColumn;
+        private Integer lastColumn;
+
+        private AutoFilterRange(int row) {
+            this.row = row;
+        }
+
+        private void include(int column) {
+            if (firstColumn == null || column < firstColumn) {
+                firstColumn = column;
+            }
+            if (lastColumn == null || column > lastColumn) {
+                lastColumn = column;
+            }
+        }
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/TemplateOoxmlPackageWriter.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/TemplateOoxmlPackageWriter.java
@@ -1,0 +1,584 @@
+package io.luchta.forma4j.writer.engine.strategy.ooxml;
+
+import org.apache.poi.ss.util.WorkbookUtil;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.SAXException;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerException;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Enumeration;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+final class TemplateOoxmlPackageWriter {
+    private static final String RELATIONSHIPS_NAMESPACE =
+            "http://schemas.openxmlformats.org/package/2006/relationships";
+    private static final String OFFICE_RELATIONSHIPS_NAMESPACE =
+            "http://schemas.openxmlformats.org/officeDocument/2006/relationships";
+    private static final String CONTENT_TYPES_NAMESPACE =
+            "http://schemas.openxmlformats.org/package/2006/content-types";
+    private static final String WORKSHEET_RELATIONSHIP =
+            OFFICE_RELATIONSHIPS_NAMESPACE + "/worksheet";
+    private static final String STYLES_RELATIONSHIP =
+            OFFICE_RELATIONSHIPS_NAMESPACE + "/styles";
+    private static final String CALC_CHAIN_RELATIONSHIP =
+            OFFICE_RELATIONSHIPS_NAMESPACE + "/calcChain";
+
+    private final Path template;
+    private final WorksheetXmlWriter worksheetWriter = new WorksheetXmlWriter();
+
+    TemplateOoxmlPackageWriter(Path template) {
+        this.template = template;
+    }
+
+    void write(
+            OutputStream output,
+            Map<String, SheetState> requestedSheets,
+            OoxmlStyleRegistry styleRegistry,
+            boolean formulas
+    ) throws IOException {
+        try (ZipFile zip = new ZipFile(template.toFile())) {
+            rejectUnsupportedPackage(zip);
+            Metadata metadata = Metadata.read(zip);
+            metadata.addRequestedSheets(requestedSheets);
+            if (formulas) {
+                metadata.enableFormulaRecalculation();
+            }
+
+            OoxmlStyleRegistry.PreparedStyles preparedStyles;
+            boolean rewriteStyles = styleRegistry.hasCustomStyles();
+            if (rewriteStyles) {
+                ZipEntry styleEntry = metadata.stylesPart == null
+                        ? null
+                        : zip.getEntry(metadata.stylesPart);
+                try (InputStream input = styleEntry == null ? null : zip.getInputStream(styleEntry)) {
+                    preparedStyles = styleRegistry.prepareTemplate(input);
+                }
+                metadata.ensureStylesPart();
+            } else {
+                preparedStyles = styleRegistry.prepareBlank();
+            }
+
+            ZipOutputStream result = new ZipOutputStream(output);
+            Enumeration<? extends ZipEntry> entries = zip.entries();
+            while (entries.hasMoreElements()) {
+                ZipEntry entry = entries.nextElement();
+                String name = entry.getName();
+                if (entry.isDirectory()
+                        || metadata.shouldSkip(
+                                name,
+                                requestedSheets,
+                                rewriteStyles,
+                                formulas
+                        )) {
+                    continue;
+                }
+                putEntry(result, name);
+                try (InputStream input = zip.getInputStream(entry)) {
+                    copy(input, result);
+                }
+                result.closeEntry();
+            }
+
+            writeDocument(result, "[Content_Types].xml", metadata.contentTypes);
+            writeDocument(result, metadata.workbookPart, metadata.workbook);
+            writeDocument(result, metadata.workbookRelationshipsPart, metadata.workbookRelationships);
+
+            if (rewriteStyles) {
+                putEntry(result, metadata.stylesPart);
+                preparedStyles.write(result);
+                result.closeEntry();
+            }
+
+            for (Map.Entry<String, SheetState> requested : requestedSheets.entrySet()) {
+                String part = metadata.sheetParts.get(requested.getKey());
+                if (part == null) {
+                    throw new IOException("ワークシートのパーツを解決できません: " + requested.getKey());
+                }
+                SheetState state = requested.getValue();
+                if (!state.hasChanges() && zip.getEntry(part) != null) {
+                    continue;
+                }
+                putEntry(result, part);
+                ZipEntry original = zip.getEntry(part);
+                if (original == null) {
+                    worksheetWriter.writeBlank(result, state, preparedStyles, metadata.date1904);
+                } else {
+                    try (InputStream input = zip.getInputStream(original)) {
+                        worksheetWriter.transform(
+                                input,
+                                result,
+                                state,
+                                preparedStyles,
+                                metadata.date1904
+                        );
+                    }
+                }
+                result.closeEntry();
+            }
+
+            // 変更対象だが空だった既存シートは上のコピー経路で既に出力されています。
+            result.finish();
+            result.flush();
+        }
+    }
+
+    private void rejectUnsupportedPackage(ZipFile zip) {
+        Enumeration<? extends ZipEntry> entries = zip.entries();
+        while (entries.hasMoreElements()) {
+            String name = entries.nextElement().getName();
+            String lower = name.toLowerCase();
+            if (lower.startsWith("_xmlsignatures/")) {
+                throw new IllegalArgumentException("電子署名付きテンプレートには出力できません。");
+            }
+            if (lower.endsWith("/vbaproject.bin") || lower.equals("xl/vbaproject.bin")) {
+                throw new IllegalArgumentException("マクロ付きテンプレートには出力できません。");
+            }
+        }
+    }
+
+    private static void writeDocument(
+            ZipOutputStream zip,
+            String name,
+            Document document
+    ) throws IOException {
+        putEntry(zip, name);
+        try {
+            TransformerFactory factory = TransformerFactory.newInstance();
+            try {
+                factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            } catch (TransformerException ignored) {
+                // 実装が対応しない場合も外部リソースは使用しません。
+            }
+            Transformer transformer = factory.newTransformer();
+            transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+            transformer.setOutputProperty(OutputKeys.OMIT_XML_DECLARATION, "no");
+            transformer.transform(new DOMSource(document), new StreamResult(zip));
+        } catch (TransformerException e) {
+            throw new IOException("OOXMLパーツの書込みに失敗しました: " + name, e);
+        }
+        zip.closeEntry();
+    }
+
+    private static void putEntry(ZipOutputStream zip, String name) throws IOException {
+        zip.putNextEntry(new ZipEntry(name));
+    }
+
+    private static void copy(InputStream input, OutputStream output) throws IOException {
+        byte[] buffer = new byte[8192];
+        int length;
+        while ((length = input.read(buffer)) >= 0) {
+            output.write(buffer, 0, length);
+        }
+    }
+
+    private static final class Metadata {
+        private final Document contentTypes;
+        private final Document workbook;
+        private final Document workbookRelationships;
+        private final String workbookPart;
+        private final String workbookRelationshipsPart;
+        private final String workbookDirectory;
+        private final Map<String, String> relationshipTargets = new HashMap<>();
+        private final Map<String, String> sheetParts = new LinkedHashMap<>();
+        private final Set<String> newSheetParts = new HashSet<>();
+        private String stylesPart;
+        private String calcChainPart;
+        private boolean date1904;
+        private int nextSheetId;
+        private int nextRelationshipId;
+        private int nextSheetPartNumber;
+
+        private Metadata(
+                Document contentTypes,
+                Document workbook,
+                Document workbookRelationships,
+                String workbookPart,
+                String workbookRelationshipsPart
+        ) {
+            this.contentTypes = contentTypes;
+            this.workbook = workbook;
+            this.workbookRelationships = workbookRelationships;
+            this.workbookPart = workbookPart;
+            this.workbookRelationshipsPart = workbookRelationshipsPart;
+            int slash = workbookPart.lastIndexOf('/');
+            workbookDirectory = slash < 0 ? "" : workbookPart.substring(0, slash + 1);
+        }
+
+        static Metadata read(ZipFile zip) throws IOException {
+            Document contentTypes = parse(zip, "[Content_Types].xml");
+            Document rootRelationships = parse(zip, "_rels/.rels");
+            String workbookPart = null;
+            NodeList rootRelations = rootRelationships.getElementsByTagNameNS(
+                    RELATIONSHIPS_NAMESPACE,
+                    "Relationship"
+            );
+            for (int index = 0; index < rootRelations.getLength(); index++) {
+                Element relationship = (Element) rootRelations.item(index);
+                if (relationship.getAttribute("Type").endsWith("/officeDocument")) {
+                    workbookPart = normalizePart("", relationship.getAttribute("Target"));
+                    break;
+                }
+            }
+            if (workbookPart == null) {
+                throw new IOException("テンプレートのworkbookパーツを解決できません。");
+            }
+            String relationshipsPart = relationshipPart(workbookPart);
+            Metadata result = new Metadata(
+                    contentTypes,
+                    parse(zip, workbookPart),
+                    parse(zip, relationshipsPart),
+                    workbookPart,
+                    relationshipsPart
+            );
+            result.index();
+            return result;
+        }
+
+        private void index() {
+            NodeList relations = workbookRelationships.getElementsByTagNameNS(
+                    RELATIONSHIPS_NAMESPACE,
+                    "Relationship"
+            );
+            for (int index = 0; index < relations.getLength(); index++) {
+                Element relationship = (Element) relations.item(index);
+                String id = relationship.getAttribute("Id");
+                String type = relationship.getAttribute("Type");
+                String part = normalizePart(workbookDirectory, relationship.getAttribute("Target"));
+                relationshipTargets.put(id, part);
+                nextRelationshipId = Math.max(nextRelationshipId, numericSuffix(id) + 1);
+                if (type.endsWith("/styles")) {
+                    stylesPart = part;
+                } else if (type.endsWith("/calcChain")) {
+                    calcChainPart = part;
+                }
+            }
+
+            NodeList workbookSheets = workbook.getElementsByTagNameNS(
+                    WorksheetXmlWriter.SPREADSHEET_NAMESPACE,
+                    "sheet"
+            );
+            for (int index = 0; index < workbookSheets.getLength(); index++) {
+                Element sheet = (Element) workbookSheets.item(index);
+                String relationshipId = sheet.getAttributeNS(
+                        OFFICE_RELATIONSHIPS_NAMESPACE,
+                        "id"
+                );
+                sheetParts.put(sheet.getAttribute("name"), relationshipTargets.get(relationshipId));
+                nextSheetId = Math.max(
+                        nextSheetId,
+                        parseInteger(sheet.getAttribute("sheetId"), index + 1) + 1
+                );
+            }
+            if (nextSheetId == 0) {
+                nextSheetId = 1;
+            }
+            if (nextRelationshipId == 0) {
+                nextRelationshipId = 1;
+            }
+
+            for (String part : relationshipTargets.values()) {
+                String name = part.substring(part.lastIndexOf('/') + 1);
+                if (name.startsWith("sheet") && name.endsWith(".xml")) {
+                    nextSheetPartNumber = Math.max(
+                            nextSheetPartNumber,
+                            parseInteger(name.substring(5, name.length() - 4), 0) + 1
+                    );
+                }
+            }
+            if (nextSheetPartNumber == 0) {
+                nextSheetPartNumber = 1;
+            }
+
+            NodeList properties = workbook.getElementsByTagNameNS(
+                    WorksheetXmlWriter.SPREADSHEET_NAMESPACE,
+                    "workbookPr"
+            );
+            if (properties.getLength() > 0) {
+                String value = ((Element) properties.item(0)).getAttribute("date1904");
+                date1904 = "1".equals(value) || "true".equalsIgnoreCase(value);
+            }
+        }
+
+        private void addRequestedSheets(Map<String, SheetState> requested) {
+            for (String sheetName : requested.keySet()) {
+                WorkbookUtil.validateSheetName(sheetName);
+                if (sheetParts.containsKey(sheetName)) {
+                    continue;
+                }
+                addSheet(sheetName);
+            }
+        }
+
+        private void addSheet(String name) {
+            String relationshipId = nextRelationshipId();
+            String relativeTarget = "worksheets/sheet" + nextSheetPartNumber++ + ".xml";
+            String part = normalizePart(workbookDirectory, relativeTarget);
+
+            Element relationship = workbookRelationships.createElementNS(
+                    RELATIONSHIPS_NAMESPACE,
+                    "Relationship"
+            );
+            relationship.setAttribute("Id", relationshipId);
+            relationship.setAttribute("Type", WORKSHEET_RELATIONSHIP);
+            relationship.setAttribute("Target", relativeTarget);
+            workbookRelationships.getDocumentElement().appendChild(relationship);
+
+            NodeList sheetContainers = workbook.getElementsByTagNameNS(
+                    WorksheetXmlWriter.SPREADSHEET_NAMESPACE,
+                    "sheets"
+            );
+            Element sheetsElement;
+            if (sheetContainers.getLength() == 0) {
+                sheetsElement = workbook.createElementNS(
+                        WorksheetXmlWriter.SPREADSHEET_NAMESPACE,
+                        "sheets"
+                );
+                workbook.getDocumentElement().appendChild(sheetsElement);
+            } else {
+                sheetsElement = (Element) sheetContainers.item(0);
+            }
+            Element sheet = workbook.createElementNS(
+                    WorksheetXmlWriter.SPREADSHEET_NAMESPACE,
+                    "sheet"
+            );
+            sheet.setAttribute("name", name);
+            sheet.setAttribute("sheetId", Integer.toString(nextSheetId++));
+            sheet.setAttributeNS(
+                    OFFICE_RELATIONSHIPS_NAMESPACE,
+                    "r:id",
+                    relationshipId
+            );
+            sheetsElement.appendChild(sheet);
+
+            addContentType(part,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.worksheet+xml");
+            sheetParts.put(name, part);
+            newSheetParts.add(part);
+        }
+
+        private void ensureStylesPart() {
+            if (stylesPart != null) {
+                return;
+            }
+            String relationshipId = nextRelationshipId();
+            String relativeTarget = "styles.xml";
+            stylesPart = normalizePart(workbookDirectory, relativeTarget);
+            Element relationship = workbookRelationships.createElementNS(
+                    RELATIONSHIPS_NAMESPACE,
+                    "Relationship"
+            );
+            relationship.setAttribute("Id", relationshipId);
+            relationship.setAttribute("Type", STYLES_RELATIONSHIP);
+            relationship.setAttribute("Target", relativeTarget);
+            workbookRelationships.getDocumentElement().appendChild(relationship);
+            addContentType(
+                    stylesPart,
+                    "application/vnd.openxmlformats-officedocument.spreadsheetml.styles+xml"
+            );
+        }
+
+        private void enableFormulaRecalculation() {
+            NodeList calculations = workbook.getElementsByTagNameNS(
+                    WorksheetXmlWriter.SPREADSHEET_NAMESPACE,
+                    "calcPr"
+            );
+            Element calculation;
+            if (calculations.getLength() == 0) {
+                calculation = workbook.createElementNS(
+                        WorksheetXmlWriter.SPREADSHEET_NAMESPACE,
+                        "calcPr"
+                );
+                NodeList extensions = workbook.getElementsByTagNameNS(
+                        WorksheetXmlWriter.SPREADSHEET_NAMESPACE,
+                        "extLst"
+                );
+                if (extensions.getLength() == 0) {
+                    workbook.getDocumentElement().appendChild(calculation);
+                } else {
+                    workbook.getDocumentElement().insertBefore(
+                            calculation,
+                            extensions.item(0)
+                    );
+                }
+            } else {
+                calculation = (Element) calculations.item(0);
+            }
+            calculation.setAttribute("calcMode", "auto");
+            calculation.setAttribute("fullCalcOnLoad", "1");
+            calculation.setAttribute("forceFullCalc", "1");
+
+            List<Element> toRemove = new ArrayList<>();
+            NodeList relations = workbookRelationships.getElementsByTagNameNS(
+                    RELATIONSHIPS_NAMESPACE,
+                    "Relationship"
+            );
+            for (int index = 0; index < relations.getLength(); index++) {
+                Element relation = (Element) relations.item(index);
+                if (relation.getAttribute("Type").endsWith("/calcChain")) {
+                    toRemove.add(relation);
+                }
+            }
+            for (Element relation : toRemove) {
+                relation.getParentNode().removeChild(relation);
+            }
+            if (calcChainPart != null) {
+                removeContentType(calcChainPart);
+            }
+        }
+
+        private boolean shouldSkip(
+                String name,
+                Map<String, SheetState> requestedSheets,
+                boolean rewriteStyles,
+                boolean formulas
+        ) {
+            if ("[Content_Types].xml".equals(name)
+                    || workbookPart.equals(name)
+                    || workbookRelationshipsPart.equals(name)) {
+                return true;
+            }
+            if (rewriteStyles && name.equals(stylesPart)) {
+                return true;
+            }
+            if (formulas && name.equals(calcChainPart)) {
+                return true;
+            }
+            for (Map.Entry<String, SheetState> requested : requestedSheets.entrySet()) {
+                String part = sheetParts.get(requested.getKey());
+                if (name.equals(part)
+                        && (requested.getValue().hasChanges() || newSheetParts.contains(name))) {
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        private void addContentType(String part, String contentType) {
+            Element override = contentTypes.createElementNS(
+                    CONTENT_TYPES_NAMESPACE,
+                    "Override"
+            );
+            override.setAttribute("PartName", "/" + part);
+            override.setAttribute("ContentType", contentType);
+            contentTypes.getDocumentElement().appendChild(override);
+        }
+
+        private void removeContentType(String part) {
+            List<Element> toRemove = new ArrayList<>();
+            NodeList overrides = contentTypes.getElementsByTagNameNS(
+                    CONTENT_TYPES_NAMESPACE,
+                    "Override"
+            );
+            for (int index = 0; index < overrides.getLength(); index++) {
+                Element override = (Element) overrides.item(index);
+                if (("/" + part).equals(override.getAttribute("PartName"))) {
+                    toRemove.add(override);
+                }
+            }
+            for (Element override : toRemove) {
+                override.getParentNode().removeChild(override);
+            }
+        }
+
+        private String nextRelationshipId() {
+            String candidate;
+            do {
+                candidate = "rId" + nextRelationshipId++;
+            } while (relationshipTargets.containsKey(candidate));
+            return candidate;
+        }
+    }
+
+    private static Document parse(ZipFile zip, String part) throws IOException {
+        ZipEntry entry = zip.getEntry(part);
+        if (entry == null) {
+            throw new IOException("テンプレートに必要なOOXMLパーツがありません: " + part);
+        }
+        try (InputStream input = zip.getInputStream(entry)) {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setNamespaceAware(true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setFeature("http://xml.org/sax/features/external-general-entities", false);
+            factory.setFeature("http://xml.org/sax/features/external-parameter-entities", false);
+            factory.setXIncludeAware(false);
+            factory.setExpandEntityReferences(false);
+            DocumentBuilder builder = factory.newDocumentBuilder();
+            return builder.parse(input);
+        } catch (ParserConfigurationException | SAXException e) {
+            throw new IOException("OOXMLパーツの解析に失敗しました: " + part, e);
+        }
+    }
+
+    private static String relationshipPart(String part) {
+        int slash = part.lastIndexOf('/');
+        String directory = slash < 0 ? "" : part.substring(0, slash + 1);
+        String file = slash < 0 ? part : part.substring(slash + 1);
+        return directory + "_rels/" + file + ".rels";
+    }
+
+    private static String normalizePart(String baseDirectory, String target) {
+        String value = target.replace('\\', '/');
+        if (value.startsWith("/")) {
+            value = value.substring(1);
+        } else {
+            value = baseDirectory + value;
+        }
+        List<String> normalized = new ArrayList<>();
+        for (String segment : value.split("/")) {
+            if (segment.isEmpty() || ".".equals(segment)) {
+                continue;
+            }
+            if ("..".equals(segment)) {
+                if (!normalized.isEmpty()) {
+                    normalized.remove(normalized.size() - 1);
+                }
+            } else {
+                normalized.add(segment);
+            }
+        }
+        return String.join("/", normalized);
+    }
+
+    private static int numericSuffix(String value) {
+        int index = value.length() - 1;
+        while (index >= 0 && Character.isDigit(value.charAt(index))) {
+            index--;
+        }
+        if (index == value.length() - 1) {
+            return 0;
+        }
+        return parseInteger(value.substring(index + 1), 0);
+    }
+
+    private static int parseInteger(String value, int fallback) {
+        try {
+            return Integer.parseInt(value);
+        } catch (NumberFormatException e) {
+            return fallback;
+        }
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/WorksheetXmlWriter.java
+++ b/src/main/java/io/luchta/forma4j/writer/engine/strategy/ooxml/WorksheetXmlWriter.java
@@ -1,0 +1,625 @@
+package io.luchta.forma4j.writer.engine.strategy.ooxml;
+
+import org.apache.poi.ss.usermodel.DateUtil;
+
+import javax.xml.XMLConstants;
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLOutputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
+import javax.xml.stream.XMLStreamWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class WorksheetXmlWriter {
+    static final String SPREADSHEET_NAMESPACE =
+            "http://schemas.openxmlformats.org/spreadsheetml/2006/main";
+
+    private final XMLInputFactory inputFactory;
+    private final XMLOutputFactory outputFactory = XMLOutputFactory.newFactory();
+
+    WorksheetXmlWriter() {
+        inputFactory = XMLInputFactory.newFactory();
+        setIfSupported(XMLInputFactory.SUPPORT_DTD, false);
+        setIfSupported("javax.xml.stream.isSupportingExternalEntities", false);
+    }
+
+    void writeBlank(
+            OutputStream output,
+            SheetState sheet,
+            OoxmlStyleRegistry.PreparedStyles styles,
+            boolean date1904
+    ) throws IOException {
+        try (CellCommandStore.SortedIterator commands = sheet.commands.sortedIterator()) {
+            XMLStreamWriter writer = outputFactory.createXMLStreamWriter(output, "UTF-8");
+            writer.writeStartDocument("UTF-8", "1.0");
+            writer.writeStartElement("worksheet");
+            writer.writeDefaultNamespace(SPREADSHEET_NAMESPACE);
+            writeColumns(writer, sheet.columnWidths);
+            writer.writeStartElement("sheetData");
+            CommandCursor cursor = new CommandCursor(commands);
+            while (cursor.has()) {
+                writeCommandRow(writer, cursor, styles, date1904);
+            }
+            writer.writeEndElement();
+            writeAutoFilter(writer, sheet.autoFilterReference());
+            writer.writeEndElement();
+            writer.writeEndDocument();
+            writer.flush();
+        } catch (XMLStreamException e) {
+            throw new IOException("ワークシートXMLの生成に失敗しました。", e);
+        }
+    }
+
+    void transform(
+            InputStream input,
+            OutputStream output,
+            SheetState sheet,
+            OoxmlStyleRegistry.PreparedStyles styles,
+            boolean date1904
+    ) throws IOException {
+        try (CellCommandStore.SortedIterator commands = sheet.commands.sortedIterator()) {
+            XMLStreamReader reader = inputFactory.createXMLStreamReader(input);
+            XMLStreamWriter writer = outputFactory.createXMLStreamWriter(output, "UTF-8");
+            CommandCursor cursor = new CommandCursor(commands);
+            boolean columnsWritten = false;
+            boolean filterWritten = false;
+            String filterReference = sheet.autoFilterReference();
+
+            writer.writeStartDocument("UTF-8", "1.0");
+            while (reader.hasNext()) {
+                int event = reader.next();
+                if (event == XMLStreamConstants.START_DOCUMENT
+                        || event == XMLStreamConstants.END_DOCUMENT) {
+                    continue;
+                }
+                if (event == XMLStreamConstants.START_ELEMENT) {
+                    String localName = reader.getLocalName();
+                    if ("dimension".equals(localName)) {
+                        skipElement(reader);
+                        continue;
+                    }
+                    if ("cols".equals(localName)) {
+                        copyColumns(reader, writer, sheet.columnWidths);
+                        columnsWritten = true;
+                        continue;
+                    }
+                    if ("sheetData".equals(localName)) {
+                        if (!columnsWritten && !sheet.columnWidths.isEmpty()) {
+                            writeColumns(writer, sheet.columnWidths);
+                            columnsWritten = true;
+                        }
+                        copyStartElement(reader, writer);
+                        transformSheetData(reader, writer, cursor, styles, date1904);
+                        continue;
+                    }
+                    if ("autoFilter".equals(localName) && filterReference != null) {
+                        skipElement(reader);
+                        writeAutoFilter(writer, filterReference);
+                        filterWritten = true;
+                        continue;
+                    }
+                    if (filterReference != null
+                            && !filterWritten
+                            && isAfterAutoFilter(localName)) {
+                        writeAutoFilter(writer, filterReference);
+                        filterWritten = true;
+                    }
+                    copyStartElement(reader, writer);
+                } else if (event == XMLStreamConstants.END_ELEMENT) {
+                    if ("worksheet".equals(reader.getLocalName())
+                            && filterReference != null
+                            && !filterWritten) {
+                        writeAutoFilter(writer, filterReference);
+                        filterWritten = true;
+                    }
+                    writer.writeEndElement();
+                } else {
+                    copyNonElementEvent(reader, writer, event);
+                }
+            }
+            writer.writeEndDocument();
+            writer.flush();
+            reader.close();
+        } catch (XMLStreamException e) {
+            throw new IOException("テンプレートのワークシートXML変換に失敗しました。", e);
+        }
+    }
+
+    private void transformSheetData(
+            XMLStreamReader reader,
+            XMLStreamWriter writer,
+            CommandCursor cursor,
+            OoxmlStyleRegistry.PreparedStyles styles,
+            boolean date1904
+    ) throws XMLStreamException {
+        int inferredRow = -1;
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT
+                    && "row".equals(reader.getLocalName())) {
+                String rowAttribute = reader.getAttributeValue(null, "r");
+                int row = rowAttribute == null
+                        ? inferredRow + 1
+                        : Integer.parseInt(rowAttribute) - 1;
+                inferredRow = row;
+                while (cursor.has() && cursor.current().row < row) {
+                    writeCommandRow(writer, cursor, styles, date1904);
+                }
+                transformRow(reader, writer, row, cursor, styles, date1904);
+                continue;
+            }
+            if (event == XMLStreamConstants.END_ELEMENT
+                    && "sheetData".equals(reader.getLocalName())) {
+                while (cursor.has()) {
+                    writeCommandRow(writer, cursor, styles, date1904);
+                }
+                writer.writeEndElement();
+                return;
+            }
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                copyElement(reader, writer);
+            } else {
+                copyNonElementEvent(reader, writer, event);
+            }
+        }
+    }
+
+    private void transformRow(
+            XMLStreamReader reader,
+            XMLStreamWriter writer,
+            int row,
+            CommandCursor cursor,
+            OoxmlStyleRegistry.PreparedStyles styles,
+            boolean date1904
+    ) throws XMLStreamException {
+        copyStartElement(reader, writer);
+        int inferredColumn = -1;
+        boolean pendingCellsWritten = false;
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT
+                    && "c".equals(reader.getLocalName())) {
+                String reference = reader.getAttributeValue(null, "r");
+                int column = reference == null
+                        ? inferredColumn + 1
+                        : CellReferences.columnIndex(reference);
+                inferredColumn = column;
+                while (cursor.isAtRow(row) && cursor.current().column < column) {
+                    writeCell(writer, cursor.take(), null, styles, date1904);
+                }
+                if (cursor.isAt(row, column)) {
+                    String existingStyle = reader.getAttributeValue(null, "s");
+                    skipElement(reader);
+                    writeCell(writer, cursor.take(), existingStyle, styles, date1904);
+                } else {
+                    copyElement(reader, writer);
+                }
+                continue;
+            }
+            if (event == XMLStreamConstants.END_ELEMENT
+                    && "row".equals(reader.getLocalName())) {
+                while (cursor.isAtRow(row)) {
+                    writeCell(writer, cursor.take(), null, styles, date1904);
+                }
+                writer.writeEndElement();
+                return;
+            }
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                if (!pendingCellsWritten) {
+                    while (cursor.isAtRow(row)) {
+                        writeCell(writer, cursor.take(), null, styles, date1904);
+                    }
+                    pendingCellsWritten = true;
+                }
+                copyElement(reader, writer);
+            } else {
+                copyNonElementEvent(reader, writer, event);
+            }
+        }
+    }
+
+    private void writeCommandRow(
+            XMLStreamWriter writer,
+            CommandCursor cursor,
+            OoxmlStyleRegistry.PreparedStyles styles,
+            boolean date1904
+    ) throws XMLStreamException {
+        int row = cursor.current().row;
+        writer.writeStartElement("row");
+        writer.writeAttribute("r", Integer.toString(row + 1));
+        while (cursor.isAtRow(row)) {
+            writeCell(writer, cursor.take(), null, styles, date1904);
+        }
+        writer.writeEndElement();
+    }
+
+    private void writeCell(
+            XMLStreamWriter writer,
+            CellCommand command,
+            String existingStyle,
+            OoxmlStyleRegistry.PreparedStyles styles,
+            boolean date1904
+    ) throws XMLStreamException {
+        writer.writeStartElement("c");
+        writer.writeAttribute("r", CellReferences.cell(command.row, command.column));
+        if (command.emptyStyle && existingStyle != null) {
+            writer.writeAttribute("s", existingStyle);
+        } else if (command.styleToken >= 0) {
+            writer.writeAttribute("s", Integer.toString(styles.styleId(command.styleToken)));
+        }
+
+        switch (command.type) {
+            case TEXT:
+                writer.writeAttribute("t", "inlineStr");
+                writer.writeStartElement("is");
+                writer.writeStartElement("t");
+                writer.writeAttribute("xml", XMLConstants.XML_NS_URI, "space", "preserve");
+                writer.writeCharacters(command.value);
+                writer.writeEndElement();
+                writer.writeEndElement();
+                break;
+            case BOOLEAN:
+                writer.writeAttribute("t", "b");
+                writeValue(writer, command.value);
+                break;
+            case NUMERIC:
+                writeValue(writer, command.value);
+                break;
+            case DATE:
+                writeValue(
+                        writer,
+                        Double.toString(DateUtil.getExcelDate(
+                                LocalDate.parse(command.value),
+                                date1904
+                        ))
+                );
+                break;
+            case DATETIME:
+                writeValue(
+                        writer,
+                        Double.toString(DateUtil.getExcelDate(
+                                LocalDateTime.parse(command.value),
+                                date1904
+                        ))
+                );
+                break;
+            case FORMULA:
+                writer.writeStartElement("f");
+                writer.writeCharacters(command.value);
+                writer.writeEndElement();
+                break;
+            default:
+                throw new IllegalStateException("未対応のセル型です: " + command.type);
+        }
+        writer.writeEndElement();
+    }
+
+    private void writeValue(XMLStreamWriter writer, String value) throws XMLStreamException {
+        writer.writeStartElement("v");
+        writer.writeCharacters(value);
+        writer.writeEndElement();
+    }
+
+    private void copyColumns(
+            XMLStreamReader reader,
+            XMLStreamWriter writer,
+            Map<Integer, Integer> widths
+    ) throws XMLStreamException {
+        copyStartElement(reader, writer);
+        List<ColumnDefinition> definitions = new ArrayList<>();
+        while (reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.END_ELEMENT
+                    && "cols".equals(reader.getLocalName())) {
+                mergeColumnWidths(definitions, widths);
+                for (ColumnDefinition definition : definitions) {
+                    definition.write(writer);
+                }
+                writer.writeEndElement();
+                return;
+            }
+            if (event == XMLStreamConstants.START_ELEMENT
+                    && "col".equals(reader.getLocalName())) {
+                definitions.add(ColumnDefinition.read(reader));
+                skipElement(reader);
+            } else if (event == XMLStreamConstants.START_ELEMENT) {
+                copyElement(reader, writer);
+            } else {
+                copyNonElementEvent(reader, writer, event);
+            }
+        }
+    }
+
+    private void writeColumns(XMLStreamWriter writer, Map<Integer, Integer> widths)
+            throws XMLStreamException {
+        if (widths.isEmpty()) {
+            return;
+        }
+        writer.writeStartElement("cols");
+        writeColumnDefinitions(writer, widths);
+        writer.writeEndElement();
+    }
+
+    private void writeColumnDefinitions(
+            XMLStreamWriter writer,
+            Map<Integer, Integer> widths
+    ) throws XMLStreamException {
+        for (Map.Entry<Integer, Integer> entry : widths.entrySet()) {
+            writer.writeEmptyElement("col");
+            writer.writeAttribute("min", Integer.toString(entry.getKey() + 1));
+            writer.writeAttribute("max", Integer.toString(entry.getKey() + 1));
+            writer.writeAttribute("width", Integer.toString(entry.getValue()));
+            writer.writeAttribute("customWidth", "1");
+        }
+    }
+
+    private void mergeColumnWidths(
+            List<ColumnDefinition> definitions,
+            Map<Integer, Integer> widths
+    ) {
+        for (Map.Entry<Integer, Integer> width : widths.entrySet()) {
+            int column = width.getKey() + 1;
+            List<ColumnDefinition> merged = new ArrayList<>();
+            boolean found = false;
+            for (ColumnDefinition definition : definitions) {
+                if (column < definition.min || column > definition.max) {
+                    merged.add(definition);
+                    continue;
+                }
+                found = true;
+                if (definition.min < column) {
+                    merged.add(definition.range(definition.min, column - 1));
+                }
+                ColumnDefinition replacement = definition.range(column, column);
+                replacement.attributes.put("width", Integer.toString(width.getValue()));
+                replacement.attributes.put("customWidth", "1");
+                merged.add(replacement);
+                if (column < definition.max) {
+                    merged.add(definition.range(column + 1, definition.max));
+                }
+            }
+            if (!found) {
+                ColumnDefinition added = new ColumnDefinition(column, column);
+                added.attributes.put("width", Integer.toString(width.getValue()));
+                added.attributes.put("customWidth", "1");
+                merged.add(added);
+            }
+            definitions.clear();
+            definitions.addAll(merged);
+        }
+        definitions.sort(Comparator.comparingInt(definition -> definition.min));
+    }
+
+    private void writeAutoFilter(XMLStreamWriter writer, String reference)
+            throws XMLStreamException {
+        if (reference == null) {
+            return;
+        }
+        writer.writeEmptyElement("autoFilter");
+        writer.writeAttribute("ref", reference);
+    }
+
+    private boolean isAfterAutoFilter(String localName) {
+        switch (localName) {
+            case "sortState":
+            case "dataConsolidate":
+            case "customSheetViews":
+            case "mergeCells":
+            case "phoneticPr":
+            case "conditionalFormatting":
+            case "dataValidations":
+            case "hyperlinks":
+            case "printOptions":
+            case "pageMargins":
+            case "pageSetup":
+            case "headerFooter":
+            case "rowBreaks":
+            case "colBreaks":
+            case "customProperties":
+            case "cellWatches":
+            case "ignoredErrors":
+            case "smartTags":
+            case "drawing":
+            case "legacyDrawing":
+            case "legacyDrawingHF":
+            case "picture":
+            case "oleObjects":
+            case "controls":
+            case "webPublishItems":
+            case "tableParts":
+            case "extLst":
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    private void copyElement(XMLStreamReader reader, XMLStreamWriter writer)
+            throws XMLStreamException {
+        int depth = 1;
+        copyStartElement(reader, writer);
+        while (depth > 0 && reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                copyStartElement(reader, writer);
+                depth++;
+            } else if (event == XMLStreamConstants.END_ELEMENT) {
+                writer.writeEndElement();
+                depth--;
+            } else {
+                copyNonElementEvent(reader, writer, event);
+            }
+        }
+    }
+
+    private void skipElement(XMLStreamReader reader) throws XMLStreamException {
+        int depth = 1;
+        while (depth > 0 && reader.hasNext()) {
+            int event = reader.next();
+            if (event == XMLStreamConstants.START_ELEMENT) {
+                depth++;
+            } else if (event == XMLStreamConstants.END_ELEMENT) {
+                depth--;
+            }
+        }
+    }
+
+    private void copyStartElement(XMLStreamReader reader, XMLStreamWriter writer)
+            throws XMLStreamException {
+        String prefix = reader.getPrefix();
+        String namespace = reader.getNamespaceURI();
+        if (namespace == null || namespace.isEmpty()) {
+            writer.writeStartElement(reader.getLocalName());
+        } else {
+            writer.writeStartElement(prefix == null ? "" : prefix, reader.getLocalName(), namespace);
+        }
+        for (int index = 0; index < reader.getNamespaceCount(); index++) {
+            String namespacePrefix = reader.getNamespacePrefix(index);
+            String namespaceValue = reader.getNamespaceURI(index);
+            if (namespacePrefix == null) {
+                writer.writeDefaultNamespace(namespaceValue);
+            } else {
+                writer.writeNamespace(namespacePrefix, namespaceValue);
+            }
+        }
+        for (int index = 0; index < reader.getAttributeCount(); index++) {
+            String attributeNamespace = reader.getAttributeNamespace(index);
+            String attributePrefix = reader.getAttributePrefix(index);
+            if (attributeNamespace == null || attributeNamespace.isEmpty()) {
+                writer.writeAttribute(
+                        reader.getAttributeLocalName(index),
+                        reader.getAttributeValue(index)
+                );
+            } else {
+                writer.writeAttribute(
+                        attributePrefix == null ? "" : attributePrefix,
+                        attributeNamespace,
+                        reader.getAttributeLocalName(index),
+                        reader.getAttributeValue(index)
+                );
+            }
+        }
+    }
+
+    private void copyNonElementEvent(
+            XMLStreamReader reader,
+            XMLStreamWriter writer,
+            int event
+    ) throws XMLStreamException {
+        switch (event) {
+            case XMLStreamConstants.CHARACTERS:
+            case XMLStreamConstants.SPACE:
+                writer.writeCharacters(reader.getText());
+                break;
+            case XMLStreamConstants.CDATA:
+                writer.writeCData(reader.getText());
+                break;
+            case XMLStreamConstants.COMMENT:
+                writer.writeComment(reader.getText());
+                break;
+            case XMLStreamConstants.PROCESSING_INSTRUCTION:
+                writer.writeProcessingInstruction(
+                        reader.getPITarget(),
+                        reader.getPIData() == null ? "" : reader.getPIData()
+                );
+                break;
+            default:
+                break;
+        }
+    }
+
+    private void setIfSupported(String property, Object value) {
+        try {
+            inputFactory.setProperty(property, value);
+        } catch (IllegalArgumentException ignored) {
+            // 実装が対応しないプロパティは無視します。
+        }
+    }
+
+    private static final class CommandCursor {
+        private final CellCommandStore.SortedIterator iterator;
+        private CellCommand current;
+
+        private CommandCursor(CellCommandStore.SortedIterator iterator) {
+            this.iterator = iterator;
+            advance();
+        }
+
+        private boolean has() {
+            return current != null;
+        }
+
+        private CellCommand current() {
+            return current;
+        }
+
+        private boolean isAtRow(int row) {
+            return current != null && current.row == row;
+        }
+
+        private boolean isAt(int row, int column) {
+            return current != null && current.row == row && current.column == column;
+        }
+
+        private CellCommand take() {
+            CellCommand result = current;
+            advance();
+            return result;
+        }
+
+        private void advance() {
+            current = iterator.hasNext() ? iterator.next() : null;
+        }
+    }
+
+    private static final class ColumnDefinition {
+        private int min;
+        private int max;
+        private final Map<String, String> attributes = new LinkedHashMap<>();
+
+        private ColumnDefinition(int min, int max) {
+            this.min = min;
+            this.max = max;
+        }
+
+        private static ColumnDefinition read(XMLStreamReader reader) {
+            int min = Integer.parseInt(reader.getAttributeValue(null, "min"));
+            int max = Integer.parseInt(reader.getAttributeValue(null, "max"));
+            ColumnDefinition result = new ColumnDefinition(min, max);
+            for (int index = 0; index < reader.getAttributeCount(); index++) {
+                result.attributes.put(
+                        reader.getAttributeLocalName(index),
+                        reader.getAttributeValue(index)
+                );
+            }
+            return result;
+        }
+
+        private ColumnDefinition range(int newMin, int newMax) {
+            ColumnDefinition result = new ColumnDefinition(newMin, newMax);
+            result.attributes.putAll(attributes);
+            result.attributes.put("min", Integer.toString(newMin));
+            result.attributes.put("max", Integer.toString(newMax));
+            return result;
+        }
+
+        private void write(XMLStreamWriter writer) throws XMLStreamException {
+            writer.writeEmptyElement("col");
+            attributes.put("min", Integer.toString(min));
+            attributes.put("max", Integer.toString(max));
+            for (Map.Entry<String, String> attribute : attributes.entrySet()) {
+                writer.writeAttribute(attribute.getKey(), attribute.getValue());
+            }
+        }
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/processor/XlsxWriteProcessor.java
+++ b/src/main/java/io/luchta/forma4j/writer/processor/XlsxWriteProcessor.java
@@ -3,6 +3,7 @@ package io.luchta.forma4j.writer.processor;
 import io.luchta.forma4j.writer.engine.buffer.accumulater.BuildAccumulator;
 import io.luchta.forma4j.writer.engine.model.book.XlsxBook;
 import io.luchta.forma4j.writer.processor.poi.WorkbookBuilder;
+import io.luchta.forma4j.writer.engine.strategy.XlsxOutputStrategy;
 import org.apache.poi.ss.usermodel.Workbook;
 
 import java.io.IOException;
@@ -23,6 +24,7 @@ public class XlsxWriteProcessor {
      * Excelへ書き込む内容
      */
     BuildAccumulator accumulator;
+    XlsxOutputStrategy outputStrategy;
 
     /**
      * コンストラクタ
@@ -32,11 +34,24 @@ public class XlsxWriteProcessor {
         this.accumulator = accumulator;
     }
 
+    /** Strategy から直接出力するためのコンストラクタです。 */
+    public XlsxWriteProcessor(XlsxOutputStrategy outputStrategy) {
+        this.outputStrategy = outputStrategy;
+    }
+
     /**
      * Excel 書き込み処理
      * @param out 書き込み先のファイル
      */
     public void process(OutputStream out) {
+        if (outputStrategy != null) {
+            try {
+                outputStrategy.write(out);
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            return;
+        }
         WorkbookBuilder builder = new WorkbookBuilder(accumulator);
         try (Workbook workbook = builder.build()) {
             workbook.write(out);

--- a/src/main/java/io/luchta/forma4j/writer/processor/poi/CellStyleBuilder.java
+++ b/src/main/java/io/luchta/forma4j/writer/processor/poi/CellStyleBuilder.java
@@ -49,7 +49,7 @@ public class CellStyleBuilder {
      * @param workbook
      * @return CellStyleBuilder
      */
-    static CellStyleBuilder of(XlsxCellStyle style, Workbook workbook) {
+    public static CellStyleBuilder of(XlsxCellStyle style, Workbook workbook) {
         CellStyle cellStyle = workbook.createCellStyle();
         Font font = workbook.createFont();
         return new CellStyleBuilder(style, cellStyle, font, workbook);

--- a/src/main/java/io/luchta/forma4j/writer/stream/CloseableIterator.java
+++ b/src/main/java/io/luchta/forma4j/writer/stream/CloseableIterator.java
@@ -1,0 +1,14 @@
+package io.luchta.forma4j.writer.stream;
+
+import java.io.IOException;
+import java.util.Iterator;
+
+/**
+ * 使用後に閉じる必要がある Iterator です。
+ *
+ * @param <T> 要素型
+ */
+public interface CloseableIterator<T> extends Iterator<T>, AutoCloseable {
+    @Override
+    void close() throws IOException;
+}

--- a/src/main/java/io/luchta/forma4j/writer/stream/CloseableIterators.java
+++ b/src/main/java/io/luchta/forma4j/writer/stream/CloseableIterators.java
@@ -1,0 +1,52 @@
+package io.luchta.forma4j.writer.stream;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Objects;
+
+final class CloseableIterators {
+    private CloseableIterators() {
+    }
+
+    @SuppressWarnings("unchecked")
+    static <T> CloseableIterator<T> from(Iterator<? extends T> iterator) {
+        Objects.requireNonNull(iterator, "iterator");
+        if (iterator instanceof CloseableIterator<?>) {
+            return (CloseableIterator<T>) iterator;
+        }
+        return new CloseableIterator<T>() {
+            @Override
+            public boolean hasNext() {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public T next() {
+                return iterator.next();
+            }
+
+            @Override
+            public void remove() {
+                iterator.remove();
+            }
+
+            @Override
+            public void close() throws IOException {
+                if (!(iterator instanceof AutoCloseable)) {
+                    return;
+                }
+                try {
+                    ((AutoCloseable) iterator).close();
+                } catch (IOException e) {
+                    throw e;
+                } catch (Exception e) {
+                    throw new IOException("Iterator のクローズに失敗しました。", e);
+                }
+            }
+        };
+    }
+
+    static <T> CloseableIterator<T> empty() {
+        return from(java.util.Collections.<T>emptyList().iterator());
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/stream/FormaStreamingWriter.java
+++ b/src/main/java/io/luchta/forma4j/writer/stream/FormaStreamingWriter.java
@@ -1,0 +1,143 @@
+package io.luchta.forma4j.writer.stream;
+
+import io.luchta.forma4j.writer.Context;
+import io.luchta.forma4j.context.databind.json.JsonObject;
+import io.luchta.forma4j.writer.definition.XmlDocument;
+import io.luchta.forma4j.writer.definition.XmlDocumentReader;
+import io.luchta.forma4j.writer.engine.XlsxModelBuilder;
+import io.luchta.forma4j.writer.engine.strategy.StreamingOutputStrategy;
+import io.luchta.forma4j.writer.engine.strategy.ooxml.AbstractOoxmlOutputStrategy;
+
+import java.io.FilterInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+
+/**
+ * Context、JsonObject、またはルートJSON配列からXLSXを逐次生成するWriterです。
+ * セル命令を一時ファイルへ退避し、OOXMLパッケージを低メモリで逐次生成します。
+ * テンプレート指定時は未変更のOOXMLパーツを保持し、対象シートだけを変換します。
+ * {@code autoSizeColumn} は無効です。テンプレートは非暗号化の {@code .xlsx} のみを対象とし、
+ * マクロまたは電子署名を含むパッケージは受け付けません。
+ */
+public class FormaStreamingWriter {
+    /**
+     * ルートJSON配列を固定名 {@code list} として出力します。
+     *
+     * <p>引数として渡された全Streamは呼び出し側が所有し、このメソッドは閉じません。</p>
+     */
+    public void write(InputStream definitionXml, OutputStream outputXlsx, InputStream json) throws IOException {
+        XmlDocument definition = readDefinition(definitionXml);
+        Context context = new Context();
+        context.putSequence("list", JsonArraySequenceSource.borrowed(json));
+        write(definition, outputXlsx, context, null);
+    }
+
+    /**
+     * ルート JSON 配列をテンプレート XLSX へ出力します。
+     * JSON 配列は {@code list} として一度だけ列挙されます。
+     * 引数として渡された全Streamは呼び出し側が所有し、このメソッドは閉じません。
+     */
+    public void write(
+            InputStream definitionXml,
+            OutputStream outputXlsx,
+            InputStream templateXlsx,
+            InputStream json
+    ) throws IOException {
+        XmlDocument definition = readDefinition(definitionXml);
+        Context context = new Context();
+        context.putSequence("list", JsonArraySequenceSource.borrowed(json));
+        write(definition, outputXlsx, context, templateXlsx);
+    }
+
+    /**
+     * Contextを再帰コピーせず、そのまま使用してXLSXを出力します。
+     *
+     * <p>引数として渡された全Streamは呼び出し側が所有し、このメソッドは閉じません。
+     * SourceのSupplierから開いたStreamとiteratorはWriterが閉じます。</p>
+     */
+    public void write(
+            InputStream definitionXml,
+            OutputStream outputXlsx,
+            Context context
+    ) throws IOException {
+        XmlDocument definition = readDefinition(definitionXml);
+        write(definition, outputXlsx, context, null);
+    }
+
+    /**
+     * Contextを再帰コピーせず、テンプレートXLSXへ出力します。
+     *
+     * <p>引数として渡された全Streamは呼び出し側が所有し、このメソッドは閉じません。
+     * SourceのSupplierから開いたStreamとiteratorはWriterが閉じます。</p>
+     */
+    public void write(
+            InputStream definitionXml,
+            OutputStream outputXlsx,
+            InputStream templateXlsx,
+            Context context
+    ) throws IOException {
+        XmlDocument definition = readDefinition(definitionXml);
+        write(definition, outputXlsx, context, templateXlsx);
+    }
+
+    /**
+     * 既存の JsonObject を入力として、OOXMLパッケージを逐次出力します。
+     * JSON データ自体は呼び出し元が保持します。
+     * 引数として渡されたStreamは閉じません。
+     */
+    public void write(InputStream definitionXml, OutputStream outputXlsx, JsonObject jsonObject) throws IOException {
+        XmlDocument definition = readDefinition(definitionXml);
+        write(definition, outputXlsx, Context.from(jsonObject), null);
+    }
+
+    /**
+     * 既存の JsonObject をテンプレート XLSX へ出力します。
+     * JSONデータ自体は呼び出し元が保持し、Excelパッケージだけを逐次変換します。
+     * 引数として渡されたStreamは閉じません。
+     */
+    public void write(
+            InputStream definitionXml,
+            OutputStream outputXlsx,
+            InputStream templateXlsx,
+            JsonObject jsonObject
+    ) throws IOException {
+        XmlDocument definition = readDefinition(definitionXml);
+        write(definition, outputXlsx, Context.from(jsonObject), templateXlsx);
+    }
+
+    private void write(
+            XmlDocument definition,
+            OutputStream outputXlsx,
+            Context context,
+            InputStream templateXlsx
+    ) throws IOException {
+        try (SequenceSourceSession sources = new SequenceSourceSession(definition, context);
+             AbstractOoxmlOutputStrategy strategy = templateXlsx == null
+                     ? new StreamingOutputStrategy()
+                     : new PackagePreservingTemplateOutputStrategy(templateXlsx)) {
+            new XlsxModelBuilder(definition, context).write(strategy, sources::open);
+            strategy.write(outputXlsx);
+        } catch (UncheckedIOException e) {
+            IOException cause = e.getCause();
+            for (Throwable suppressed : e.getSuppressed()) {
+                cause.addSuppressed(suppressed);
+            }
+            throw cause;
+        }
+    }
+
+    private XmlDocument readDefinition(InputStream definitionXml) throws IOException {
+        return new XmlDocumentReader().read(nonClosing(definitionXml));
+    }
+
+    private InputStream nonClosing(InputStream input) {
+        return new FilterInputStream(input) {
+            @Override
+            public void close() {
+                // 呼び出し側が所有するStreamは閉じません。
+            }
+        };
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/stream/InputStreamSupplier.java
+++ b/src/main/java/io/luchta/forma4j/writer/stream/InputStreamSupplier.java
@@ -1,0 +1,12 @@
+package io.luchta.forma4j.writer.stream;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+/**
+ * Writer が所有して閉じる InputStream を生成します。
+ */
+@FunctionalInterface
+public interface InputStreamSupplier {
+    InputStream open() throws IOException;
+}

--- a/src/main/java/io/luchta/forma4j/writer/stream/IterableSequenceSource.java
+++ b/src/main/java/io/luchta/forma4j/writer/stream/IterableSequenceSource.java
@@ -1,0 +1,60 @@
+package io.luchta.forma4j.writer.stream;
+
+import java.io.IOException;
+import java.util.Iterator;
+import java.util.Objects;
+
+/**
+ * Java の Iterator または Iterable を SequenceSource として公開します。
+ *
+ * @param <T> 要素型
+ */
+public final class IterableSequenceSource<T> implements SequenceSource<T> {
+    private final Iterator<? extends T> oneShotIterator;
+    private final Iterable<? extends T> replayableIterable;
+    private final Replayability replayability;
+    private boolean opened;
+
+    private IterableSequenceSource(
+            Iterator<? extends T> oneShotIterator,
+            Iterable<? extends T> replayableIterable,
+            Replayability replayability
+    ) {
+        this.oneShotIterator = oneShotIterator;
+        this.replayableIterable = replayableIterable;
+        this.replayability = replayability;
+    }
+
+    public static <T> IterableSequenceSource<T> oneShot(Iterator<? extends T> iterator) {
+        return new IterableSequenceSource<>(
+                Objects.requireNonNull(iterator, "iterator"),
+                null,
+                Replayability.ONE_SHOT
+        );
+    }
+
+    public static <T> IterableSequenceSource<T> replayable(Iterable<? extends T> iterable) {
+        return new IterableSequenceSource<>(
+                null,
+                Objects.requireNonNull(iterable, "iterable"),
+                Replayability.REPLAYABLE
+        );
+    }
+
+    @Override
+    public synchronized CloseableIterator<T> open() throws IOException {
+        if (replayability == Replayability.ONE_SHOT) {
+            if (opened) {
+                throw new IOException("One-shot sequence has already been opened.");
+            }
+            opened = true;
+            return CloseableIterators.from(oneShotIterator);
+        }
+        return CloseableIterators.from(replayableIterable.iterator());
+    }
+
+    @Override
+    public Replayability replayability() {
+        return replayability;
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/stream/JsonArraySequenceSource.java
+++ b/src/main/java/io/luchta/forma4j/writer/stream/JsonArraySequenceSource.java
@@ -1,0 +1,163 @@
+package io.luchta.forma4j.writer.stream;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.util.NoSuchElementException;
+import java.util.Objects;
+
+/**
+ * ルート JSON 配列を要素単位で読み込む SequenceSource です。
+ *
+ * @param <T> JSONから生成されるMap、List、またはスカラーの要素型
+ */
+public final class JsonArraySequenceSource<T> implements SequenceSource<T> {
+    private final InputStreamSupplier supplier;
+    private final Replayability replayability;
+    private final boolean closeInput;
+    private boolean opened;
+
+    private JsonArraySequenceSource(
+            InputStreamSupplier supplier,
+            Replayability replayability,
+            boolean closeInput
+    ) {
+        this.supplier = supplier;
+        this.replayability = replayability;
+        this.closeInput = closeInput;
+    }
+
+    /**
+     * {@code open()} ごとに新しい InputStream を返す Supplier からSourceを作成します。
+     * WriterはSupplierから取得したInputStreamを閉じます。
+     */
+    public static <T> JsonArraySequenceSource<T> from(InputStreamSupplier supplier) {
+        return new JsonArraySequenceSource<>(
+                Objects.requireNonNull(supplier, "supplier"),
+                Replayability.REPLAYABLE,
+                true
+        );
+    }
+
+    static JsonArraySequenceSource<Object> borrowed(InputStream inputStream) {
+        return new JsonArraySequenceSource<>(
+                () -> Objects.requireNonNull(inputStream, "inputStream"),
+                Replayability.ONE_SHOT,
+                false
+        );
+    }
+
+    @Override
+    public synchronized CloseableIterator<T> open() throws IOException {
+        if (replayability == Replayability.ONE_SHOT && opened) {
+            throw new IOException("One-shot JSON sequence has already been opened.");
+        }
+        opened = true;
+
+        InputStream input = supplier.open();
+        if (input == null) {
+            throw new IOException("InputStreamSupplier returned null.");
+        }
+        JsonParser parser = null;
+        try {
+            parser = new JsonFactory().createParser(input);
+            if (!closeInput) {
+                parser.disable(JsonParser.Feature.AUTO_CLOSE_SOURCE);
+            }
+            if (parser.nextToken() != JsonToken.START_ARRAY) {
+                if (!closeInput) {
+                    throw new IllegalArgumentException(
+                            "ストリーミング入力はルート JSON 配列である必要があります。"
+                    );
+                }
+                throw new IOException("ストリーミング入力はルート JSON 配列である必要があります。");
+            }
+            return new ParserIterator<>(parser);
+        } catch (IOException | RuntimeException e) {
+            if (parser != null) {
+                try {
+                    parser.close();
+                } catch (IOException closeFailure) {
+                    e.addSuppressed(closeFailure);
+                }
+            } else if (closeInput) {
+                try {
+                    input.close();
+                } catch (IOException closeFailure) {
+                    e.addSuppressed(closeFailure);
+                }
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    public Replayability replayability() {
+        return replayability;
+    }
+
+    private static final class ParserIterator<T> implements CloseableIterator<T> {
+        private final JsonParser parser;
+        private JsonToken nextToken;
+        private boolean prepared;
+        private boolean complete;
+        private boolean closed;
+
+        private ParserIterator(JsonParser parser) {
+            this.parser = parser;
+        }
+
+        @Override
+        public boolean hasNext() {
+            prepare();
+            return !complete;
+        }
+
+        @Override
+        @SuppressWarnings("unchecked")
+        public T next() {
+            prepare();
+            if (complete) {
+                throw new NoSuchElementException();
+            }
+            try {
+                T value = (T) JsonValueCodec.read(parser, nextToken);
+                prepared = false;
+                return value;
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        private void prepare() {
+            if (prepared || complete) {
+                return;
+            }
+            try {
+                nextToken = parser.nextToken();
+                prepared = true;
+                if (nextToken == JsonToken.END_ARRAY) {
+                    complete = true;
+                    close();
+                } else if (nextToken == null) {
+                    throw new IOException("JSON 配列が途中で終了しました。");
+                }
+            } catch (IOException e) {
+                throw new UncheckedIOException(e);
+            }
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (closed) {
+                return;
+            }
+            closed = true;
+            parser.close();
+        }
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/stream/JsonValueCodec.java
+++ b/src/main/java/io/luchta/forma4j/writer/stream/JsonValueCodec.java
@@ -1,0 +1,147 @@
+package io.luchta.forma4j.writer.stream;
+
+import com.fasterxml.jackson.core.JsonGenerator;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+
+import java.io.IOException;
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+final class JsonValueCodec {
+    private JsonValueCodec() {
+    }
+
+    static Object read(JsonParser parser, JsonToken token) throws IOException {
+        if (token == JsonToken.START_OBJECT) {
+            Map<String, Object> value = new LinkedHashMap<>();
+            while (true) {
+                JsonToken field = parser.nextToken();
+                if (field == JsonToken.END_OBJECT) {
+                    return value;
+                }
+                if (field == null) {
+                    throw new IOException("JSON オブジェクトが途中で終了しました。");
+                }
+                if (field != JsonToken.FIELD_NAME) {
+                    throw new IOException("JSON オブジェクトのフィールド名が不正です。");
+                }
+                String name = parser.currentName();
+                JsonToken child = parser.nextToken();
+                if (child == null) {
+                    throw new IOException("JSON オブジェクトが途中で終了しました。");
+                }
+                value.put(name, read(parser, child));
+            }
+        }
+        if (token == JsonToken.START_ARRAY) {
+            List<Object> value = new ArrayList<>();
+            while (true) {
+                JsonToken child = parser.nextToken();
+                if (child == JsonToken.END_ARRAY) {
+                    return value;
+                }
+                if (child == null) {
+                    throw new IOException("JSON 配列が途中で終了しました。");
+                }
+                value.add(read(parser, child));
+            }
+        }
+        if (token == JsonToken.VALUE_STRING) {
+            return parser.getText();
+        }
+        if (token == JsonToken.VALUE_TRUE || token == JsonToken.VALUE_FALSE) {
+            return parser.getBooleanValue();
+        }
+        if (token == JsonToken.VALUE_NUMBER_INT) {
+            if (parser.getNumberType() == JsonParser.NumberType.BIG_INTEGER) {
+                return parser.getBigIntegerValue();
+            }
+            if (parser.getNumberType() == JsonParser.NumberType.LONG) {
+                return parser.getLongValue();
+            }
+            return parser.getIntValue();
+        }
+        if (token == JsonToken.VALUE_NUMBER_FLOAT) {
+            if (parser.getNumberType() == JsonParser.NumberType.BIG_DECIMAL) {
+                return parser.getDecimalValue();
+            }
+            return parser.getDoubleValue();
+        }
+        if (token == JsonToken.VALUE_NULL) {
+            return null;
+        }
+        throw new IOException("サポートされていない JSON トークンです: " + token);
+    }
+
+    static void write(JsonGenerator generator, Object value) throws IOException {
+        if (value == null) {
+            generator.writeNull();
+            return;
+        }
+        if (value instanceof String || value instanceof Character) {
+            generator.writeString(value.toString());
+            return;
+        }
+        if (value instanceof Boolean) {
+            generator.writeBoolean((Boolean) value);
+            return;
+        }
+        if (value instanceof BigInteger) {
+            generator.writeNumber((BigInteger) value);
+            return;
+        }
+        if (value instanceof BigDecimal) {
+            generator.writeNumber((BigDecimal) value);
+            return;
+        }
+        if (value instanceof Byte || value instanceof Short || value instanceof Integer) {
+            generator.writeNumber(((Number) value).intValue());
+            return;
+        }
+        if (value instanceof Long) {
+            generator.writeNumber((Long) value);
+            return;
+        }
+        if (value instanceof Float) {
+            generator.writeNumber((Float) value);
+            return;
+        }
+        if (value instanceof Double) {
+            generator.writeNumber((Double) value);
+            return;
+        }
+        if (value instanceof Number) {
+            generator.writeNumber(value.toString());
+            return;
+        }
+        if (value instanceof Map<?, ?>) {
+            generator.writeStartObject();
+            for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+                if (!(entry.getKey() instanceof String)) {
+                    throw new IOException("SPOOLED sequence の Map キーは String である必要があります。");
+                }
+                generator.writeFieldName((String) entry.getKey());
+                write(generator, entry.getValue());
+            }
+            generator.writeEndObject();
+            return;
+        }
+        if (value instanceof List<?>) {
+            generator.writeStartArray();
+            for (Object item : (List<?>) value) {
+                write(generator, item);
+            }
+            generator.writeEndArray();
+            return;
+        }
+        throw new IOException(
+                "SPOOLED sequence ではサポートされていない値型です: "
+                        + value.getClass().getName()
+        );
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/stream/MappingSequenceSource.java
+++ b/src/main/java/io/luchta/forma4j/writer/stream/MappingSequenceSource.java
@@ -1,0 +1,45 @@
+package io.luchta.forma4j.writer.stream;
+
+import java.io.IOException;
+import java.util.Objects;
+import java.util.function.Function;
+
+public final class MappingSequenceSource<S, T> implements SequenceSource<T> {
+    private final SequenceSource<? extends S> source;
+    private final Function<? super S, ? extends T> mapper;
+
+    MappingSequenceSource(
+            SequenceSource<? extends S> source,
+            Function<? super S, ? extends T> mapper
+    ) {
+        this.source = Objects.requireNonNull(source);
+        this.mapper = Objects.requireNonNull(mapper);
+    }
+
+    @Override
+    public CloseableIterator<T> open() throws IOException {
+        CloseableIterator<? extends S> iterator = source.open();
+
+        return new CloseableIterator<>() {
+            @Override
+            public boolean hasNext() {
+                return iterator.hasNext();
+            }
+
+            @Override
+            public T next() {
+                return mapper.apply(iterator.next());
+            }
+
+            @Override
+            public void close() throws IOException {
+                iterator.close();
+            }
+        };
+    }
+
+    @Override
+    public Replayability replayability() {
+        return source.replayability();
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/stream/PackagePreservingTemplateOutputStrategy.java
+++ b/src/main/java/io/luchta/forma4j/writer/stream/PackagePreservingTemplateOutputStrategy.java
@@ -1,0 +1,38 @@
+package io.luchta.forma4j.writer.stream;
+
+import io.luchta.forma4j.writer.engine.strategy.ooxml.AbstractOoxmlOutputStrategy;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+
+/**
+ * テンプレートのOOXMLパーツを保持し、対象ワークシートだけを逐次変換する内部戦略です。
+ */
+final class PackagePreservingTemplateOutputStrategy
+        extends AbstractOoxmlOutputStrategy {
+    private final Path template;
+
+    PackagePreservingTemplateOutputStrategy(InputStream templateXlsx) throws IOException {
+        super();
+        template = temporaryDirectory.resolve("template.xlsx");
+        try {
+            Files.copy(templateXlsx, template, StandardCopyOption.REPLACE_EXISTING);
+        } catch (IOException e) {
+            try {
+                close();
+            } catch (IOException closeFailure) {
+                e.addSuppressed(closeFailure);
+            }
+            throw e;
+        }
+    }
+
+    @Override
+    protected void writePackage(OutputStream outputStream) throws IOException {
+        writeTemplateOoxmlPackage(template, outputStream);
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/stream/Replayability.java
+++ b/src/main/java/io/luchta/forma4j/writer/stream/Replayability.java
@@ -1,0 +1,13 @@
+package io.luchta.forma4j.writer.stream;
+
+/**
+ * {@link SequenceSource} を同一の Writer 呼び出し内で再度開けるかを表します。
+ */
+public enum Replayability {
+    /** 一度だけ開くことができます。 */
+    ONE_SHOT,
+    /** {@code open()} ごとに先頭から読み直すことができます。 */
+    REPLAYABLE,
+    /** 初回に一時ファイルへ退避し、その内容を再生します。 */
+    SPOOLED
+}

--- a/src/main/java/io/luchta/forma4j/writer/stream/SequenceSource.java
+++ b/src/main/java/io/luchta/forma4j/writer/stream/SequenceSource.java
@@ -1,0 +1,25 @@
+package io.luchta.forma4j.writer.stream;
+
+import java.io.IOException;
+import java.util.function.Function;
+
+/**
+ * コレクションを全件保持せず、先頭から開くためのデータソースです。
+ *
+ * <p>{@link java.util.Iterator#hasNext()} または {@link java.util.Iterator#next()}
+ * で発生したIOExceptionは {@link java.io.UncheckedIOException} で通知してください。
+ * FormaStreamingWriterは元のIOExceptionへ戻して呼び出し元へ通知します。</p>
+ *
+ * @param <T> 要素型
+ */
+public interface SequenceSource<T> {
+    CloseableIterator<T> open() throws IOException;
+
+    Replayability replayability();
+
+    default <R> SequenceSource<R> map(
+            Function<? super T, ? extends R> mapper
+    ) {
+        return new MappingSequenceSource<>(this, mapper);
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/stream/SequenceSourceSession.java
+++ b/src/main/java/io/luchta/forma4j/writer/stream/SequenceSourceSession.java
@@ -1,0 +1,255 @@
+package io.luchta.forma4j.writer.stream;
+
+import com.fasterxml.jackson.core.JsonFactory;
+import com.fasterxml.jackson.core.JsonGenerator;
+import io.luchta.forma4j.writer.Context;
+import io.luchta.forma4j.writer.definition.XmlDocument;
+import io.luchta.forma4j.writer.definition.schema.Element;
+import io.luchta.forma4j.writer.definition.schema.element.HorizontalFor;
+import io.luchta.forma4j.writer.definition.schema.element.ListElement;
+import io.luchta.forma4j.writer.definition.schema.element.Sheet;
+import io.luchta.forma4j.writer.definition.schema.element.VerticalFor;
+
+import java.io.BufferedOutputStream;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.UncheckedIOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Comparator;
+import java.util.IdentityHashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.stream.Stream;
+
+/**
+ * FormaStreamingWriter の1回の実行内でSourceの状態と一時ファイルを管理します。
+ */
+final class SequenceSourceSession implements AutoCloseable {
+    private final Map<SequenceSource<?>, Integer> openCounts = new IdentityHashMap<>();
+    private final Map<SequenceSource<?>, Path> spools = new IdentityHashMap<>();
+    private Path temporaryDirectory;
+    private boolean closed;
+
+    SequenceSourceSession(XmlDocument definition, Context context) {
+        validateOneShotReferences(definition, context);
+    }
+
+    CloseableIterator<Object> open(String name, Object value) {
+        if (!(value instanceof SequenceSource<?>)) {
+            if (value instanceof Iterable<?>) {
+                return named(name, CloseableIterators.from(((Iterable<?>) value).iterator()));
+            }
+            return CloseableIterators.empty();
+        }
+
+        SequenceSource<?> source = (SequenceSource<?>) value;
+        try {
+            if (source.replayability() == Replayability.ONE_SHOT) {
+                int count = openCounts.getOrDefault(source, 0);
+                if (count > 0) {
+                    throw oneShotFailure(name);
+                }
+                openCounts.put(source, count + 1);
+                return named(name, source.open());
+            }
+            if (source.replayability() == Replayability.SPOOLED) {
+                return named(name, replaySpool(name, source));
+            }
+            return named(name, source.open());
+        } catch (IOException e) {
+            throw new UncheckedIOException(namedFailure(name, e));
+        }
+    }
+
+    private CloseableIterator<Object> replaySpool(
+            String name,
+            SequenceSource<?> source
+    ) throws IOException {
+        Path spool = spools.get(source);
+        if (spool == null) {
+            spool = createSpool(name, source);
+            spools.put(source, spool);
+        }
+        Path replayFile = spool;
+        return JsonArraySequenceSource.from(() -> Files.newInputStream(replayFile)).open();
+    }
+
+    private Path createSpool(String name, SequenceSource<?> source) throws IOException {
+        Path directory = temporaryDirectory();
+        Path spool = Files.createTempFile(directory, "sequence-", ".json");
+        boolean success = false;
+        try (CloseableIterator<?> iterator = source.open();
+             OutputStream output = new BufferedOutputStream(Files.newOutputStream(spool));
+             JsonGenerator generator = new JsonFactory().createGenerator(output)) {
+            generator.writeStartArray();
+            while (iterator.hasNext()) {
+                JsonValueCodec.write(generator, iterator.next());
+            }
+            generator.writeEndArray();
+            success = true;
+            return spool;
+        } catch (UncheckedIOException e) {
+            IOException failure = namedFailure(name, e.getCause());
+            for (Throwable suppressed : e.getSuppressed()) {
+                failure.addSuppressed(suppressed);
+            }
+            throw failure;
+        } catch (IOException e) {
+            throw namedFailure(name, e);
+        } finally {
+            if (!success) {
+                Files.deleteIfExists(spool);
+            }
+        }
+    }
+
+    private Path temporaryDirectory() throws IOException {
+        if (temporaryDirectory == null) {
+            temporaryDirectory = Files.createTempDirectory("forma4j-input-");
+        }
+        return temporaryDirectory;
+    }
+
+    Path temporaryDirectoryForTesting() {
+        return temporaryDirectory;
+    }
+
+    @SuppressWarnings("unchecked")
+    private CloseableIterator<Object> named(
+            String name,
+            CloseableIterator<?> iterator
+    ) {
+        CloseableIterator<Object> delegate = (CloseableIterator<Object>) iterator;
+        return new CloseableIterator<Object>() {
+            @Override
+            public boolean hasNext() {
+                try {
+                    return delegate.hasNext();
+                } catch (UncheckedIOException e) {
+                    throw new UncheckedIOException(namedFailure(name, e.getCause()));
+                }
+            }
+
+            @Override
+            public Object next() {
+                try {
+                    return delegate.next();
+                } catch (UncheckedIOException e) {
+                    throw new UncheckedIOException(namedFailure(name, e.getCause()));
+                }
+            }
+
+            @Override
+            public void remove() {
+                delegate.remove();
+            }
+
+            @Override
+            public void close() throws IOException {
+                try {
+                    delegate.close();
+                } catch (IOException e) {
+                    throw namedFailure(name, e);
+                }
+            }
+        };
+    }
+
+    private static IOException namedFailure(String name, IOException cause) {
+        String message = "failed to read collection '" + name + "'";
+        if (message.equals(cause.getMessage())) {
+            return cause;
+        }
+        return new IOException(message, cause);
+    }
+
+    private static IllegalStateException oneShotFailure(String name) {
+        return new IllegalStateException(
+                "collection '" + name + "' is one-shot but is referenced more than once"
+        );
+    }
+
+    private static void validateOneShotReferences(
+            XmlDocument definition,
+            Context context
+    ) {
+        Map<String, Integer> references = new LinkedHashMap<>();
+        for (Element element : definition.root().children()) {
+            collectReferences(element, context, references);
+        }
+        for (Map.Entry<String, Integer> reference : references.entrySet()) {
+            Object value = context.getVar(reference.getKey());
+            if (value instanceof SequenceSource<?>
+                    && ((SequenceSource<?>) value).replayability() == Replayability.ONE_SHOT
+                    && reference.getValue() > 1) {
+                throw oneShotFailure(reference.getKey());
+            }
+        }
+    }
+
+    private static void collectReferences(
+            Element element,
+            Context context,
+            Map<String, Integer> references
+    ) {
+        String collection = collectionName(element, context);
+        if (collection != null && !collection.isEmpty()) {
+            references.merge(collection, 1, Integer::sum);
+        }
+        for (Element child : element.children()) {
+            collectReferences(child, context, references);
+        }
+    }
+
+    private static String collectionName(Element element, Context context) {
+        switch (element.type()) {
+            case SHEET:
+                Sheet sheet = (Sheet) element;
+                return sheet.collection().isEmpty() ? null : sheet.collection().toString();
+            case VERTICAL_FOR:
+                return ((VerticalFor) element).collection().toString();
+            case HORIZONTAL_FOR:
+                return ((HorizontalFor) element).collection().toString();
+            case LIST:
+                ListElement list = (ListElement) element;
+                if (!list.collection().isEmpty()) {
+                    return list.collection().toString();
+                }
+                return context.getKeys().isEmpty()
+                        ? null
+                        : context.getKeys().iterator().next();
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public void close() throws IOException {
+        if (closed) {
+            return;
+        }
+        closed = true;
+        if (temporaryDirectory == null) {
+            return;
+        }
+        IOException failure = null;
+        try (Stream<Path> paths = Files.walk(temporaryDirectory)) {
+            Path[] ordered = paths.sorted(Comparator.reverseOrder()).toArray(Path[]::new);
+            for (Path path : ordered) {
+                try {
+                    Files.deleteIfExists(path);
+                } catch (IOException e) {
+                    if (failure == null) {
+                        failure = e;
+                    } else {
+                        failure.addSuppressed(e);
+                    }
+                }
+            }
+        }
+        if (failure != null) {
+            throw failure;
+        }
+    }
+}

--- a/src/main/java/io/luchta/forma4j/writer/stream/SpooledSequenceSource.java
+++ b/src/main/java/io/luchta/forma4j/writer/stream/SpooledSequenceSource.java
@@ -1,0 +1,34 @@
+package io.luchta.forma4j.writer.stream;
+
+import java.io.IOException;
+import java.util.Objects;
+
+/**
+ * 初回参照時に Writer 管理の一時ファイルへ退避する SequenceSource です。
+ *
+ * <p>要素は Map、List、文字列、数値、真偽値、null で構成される
+ * JSON 互換値である必要があります。</p>
+ *
+ * @param <T> 要素型
+ */
+public final class SpooledSequenceSource<T> implements SequenceSource<T> {
+    private final SequenceSource<? extends T> delegate;
+
+    private SpooledSequenceSource(SequenceSource<? extends T> delegate) {
+        this.delegate = delegate;
+    }
+
+    public static <T> SpooledSequenceSource<T> from(SequenceSource<? extends T> source) {
+        return new SpooledSequenceSource<>(Objects.requireNonNull(source, "source"));
+    }
+
+    @Override
+    public CloseableIterator<T> open() throws IOException {
+        return CloseableIterators.from(delegate.open());
+    }
+
+    @Override
+    public Replayability replayability() {
+        return Replayability.SPOOLED;
+    }
+}

--- a/src/test/java/io/luchta/forma4j/writer/cell/CellTest.java
+++ b/src/test/java/io/luchta/forma4j/writer/cell/CellTest.java
@@ -6,6 +6,7 @@ import io.luchta.forma4j.context.databind.json.JsonNodes;
 import io.luchta.forma4j.context.databind.json.JsonObject;
 import io.luchta.forma4j.reader.FormaReader;
 import io.luchta.forma4j.writer.FormaWriter;
+import io.luchta.forma4j.writer.stream.FormaStreamingWriter;
 import org.apache.poi.ss.usermodel.Sheet;
 import org.apache.poi.ss.usermodel.Workbook;
 import org.apache.poi.ss.usermodel.WorkbookFactory;
@@ -54,6 +55,40 @@ public class CellTest {
 
         // 書き込み
         FormaWriter sut = new FormaWriter();
+        sut.write(in, out, new JsonObject(jsonNode));
+
+        // 書き込んだ内容のチェック
+        FormaDiffer differ = new FormaDiffer();
+        FileInputStream comparing = new FileInputStream(absolutePath);
+        InputStream compared = classLoader.getResource("writer/cell/cell.xlsx").openStream();
+        JsonObject jsonObject = differ.diff(comparing, compared);
+        logger.log(Level.INFO, "比較結果: " + new JsonSerializer().serializeFromJsonObject(jsonObject));
+
+        Assertions.assertEquals(true, jsonObject.isJsonNodes());
+        Assertions.assertEquals(0, ((JsonNodes) jsonObject.getValue()).size());
+    }
+
+    /**
+     * rowIndexとcolumnIndexを指定してcellへ値を出力するテスト
+     */
+    @Test
+    public void streaming_cell_test() throws Exception {
+        // 定義ファイルの読み込み
+        ClassLoader classLoader = getClass().getClassLoader();
+        InputStream in = classLoader.getResource("writer/cell/cell.xml").openStream();
+
+        // 出力ファイルの設定
+        File outFile = Files.createTempFile("test", String.format("%s.xlsx", LocalDateTime.now().toString())).toFile();
+        FileOutputStream out = new FileOutputStream(outFile);
+        String absolutePath = outFile.getAbsolutePath();
+        logger.log(Level.INFO, "xlsxファイル出力先: " + absolutePath);
+
+        // 書き込む内容の設定
+        JsonNode jsonNode = new JsonNode();
+        jsonNode.putVar("value", new JsonObject("あいうえお"));
+
+        // 書き込み
+        FormaStreamingWriter sut = new FormaStreamingWriter();
         sut.write(in, out, new JsonObject(jsonNode));
 
         // 書き込んだ内容のチェック

--- a/src/test/java/io/luchta/forma4j/writer/engine/strategy/StreamingOutputStrategyTest.java
+++ b/src/test/java/io/luchta/forma4j/writer/engine/strategy/StreamingOutputStrategyTest.java
@@ -1,0 +1,90 @@
+package io.luchta.forma4j.writer.engine.strategy;
+
+import io.luchta.forma4j.writer.definition.schema.attribute.Name;
+import io.luchta.forma4j.writer.engine.model.cell.XlsxCell;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxCellAddress;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxColumnNumber;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxRowNumber;
+import io.luchta.forma4j.writer.engine.model.cell.address.XlsxSheetName;
+import io.luchta.forma4j.writer.engine.model.cell.style.XlsxCellStyle;
+import io.luchta.forma4j.writer.engine.model.cell.value.Text;
+import org.apache.poi.ss.usermodel.Cell;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+import org.apache.poi.xssf.usermodel.XSSFFont;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class StreamingOutputStrategyTest {
+    @Test
+    void deletesTemporaryDirectoryWhenClosed() throws Exception {
+        TestStreamingOutputStrategy strategy = new TestStreamingOutputStrategy();
+        Path temporaryDirectory = strategy.temporaryDirectory();
+        assertTrue(Files.exists(temporaryDirectory));
+
+        strategy.close();
+
+        assertFalse(Files.exists(temporaryDirectory));
+    }
+
+    @Test
+    void acceptsWritesToEarlierRowsAndUsesTheLastValue() throws Exception {
+        StreamingOutputStrategy strategy = new StreamingOutputStrategy();
+        XlsxSheetName sheet = new XlsxSheetName(new Name("result"));
+        strategy.startSheet(sheet, null);
+        for (int row = 0; row <= 5000; row++) {
+            strategy.writeCell(address(sheet, row), cell(sheet, row));
+        }
+
+        XlsxCellAddress first = address(sheet, 0);
+        strategy.writeCell(
+                first,
+                new XlsxCell(first, new Text("replacement"), new XlsxCellStyle(), null)
+        );
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        strategy.write(output);
+
+        try (XSSFWorkbook workbook = new XSSFWorkbook(
+                new ByteArrayInputStream(output.toByteArray()))) {
+            Cell firstCell = workbook.getSheet("result").getRow(0).getCell(0);
+            Cell lastCell = workbook.getSheet("result").getRow(5000).getCell(0);
+            assertEquals(
+                    "replacement",
+                    firstCell.getStringCellValue()
+            );
+            assertEquals(
+                    "value",
+                    lastCell.getStringCellValue()
+            );
+            assertNotEquals(0, firstCell.getCellStyle().getIndex());
+            assertEquals(firstCell.getCellStyle().getIndex(), lastCell.getCellStyle().getIndex());
+            XSSFFont font = workbook.getFontAt(firstCell.getCellStyle().getFontIndexAsInt());
+            assertNull(font.getXSSFColor());
+        }
+    }
+
+    private XlsxCellAddress address(XlsxSheetName sheet, int row) {
+        return new XlsxCellAddress(sheet, new XlsxRowNumber((long) row), XlsxColumnNumber.init());
+    }
+
+    private XlsxCell cell(XlsxSheetName sheet, int row) {
+        XlsxCellAddress address = address(sheet, row);
+        return new XlsxCell(address, new Text("value"), new XlsxCellStyle(), null);
+    }
+
+    private static final class TestStreamingOutputStrategy extends StreamingOutputStrategy {
+        private Path temporaryDirectory() {
+            return temporaryDirectory;
+        }
+    }
+}

--- a/src/test/java/io/luchta/forma4j/writer/stream/FormaStreamingWriterTest.java
+++ b/src/test/java/io/luchta/forma4j/writer/stream/FormaStreamingWriterTest.java
@@ -1,0 +1,229 @@
+package io.luchta.forma4j.writer.stream;
+
+import io.luchta.forma4j.context.databind.json.JsonNode;
+import io.luchta.forma4j.context.databind.json.JsonNodes;
+import io.luchta.forma4j.context.databind.json.JsonObject;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.nio.charset.StandardCharsets;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class FormaStreamingWriterTest {
+    @Test
+    void writesListHeaderAndDetailsFromOnePassJsonArray() throws Exception {
+        String definition = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<forma><sheet name=\"result\"><list collection=\"list\"/></sheet></forma>";
+        byte[] output = write(definition, "[{\"name\":\"first\",\"count\":1},{\"name\":\"second\",\"count\":2}]");
+
+        try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(output))) {
+            Sheet sheet = workbook.getSheet("result");
+            assertEquals("name", sheet.getRow(0).getCell(0).getStringCellValue());
+            assertEquals("count", sheet.getRow(0).getCell(1).getStringCellValue());
+            assertEquals("first", sheet.getRow(1).getCell(0).getStringCellValue());
+            assertEquals("2", sheet.getRow(2).getCell(1).getStringCellValue());
+        }
+    }
+
+    @Test
+    void writesMoreThanTheStreamingWindowAndIgnoresAutoSizeColumn() throws Exception {
+        String definition = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<forma><sheet name=\"result\" autoSizeColumn=\"true\">"
+                + "<vertical-for item=\"item\" collection=\"list\" startRowIndex=\"0\" startColumnIndex=\"0\">"
+                + "<row><cell style=\"width:18\">#{item.value}</cell></row>"
+                + "</vertical-for></sheet></forma>";
+        StringBuilder json = new StringBuilder("[");
+        for (int i = 0; i < 150; i++) {
+            if (i > 0) {
+                json.append(',');
+            }
+            json.append("{\"value\":\"").append(i).append("\"}");
+        }
+        json.append(']');
+
+        byte[] output = write(definition, json.toString());
+        try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(output))) {
+            Sheet sheet = workbook.getSheet("result");
+            assertEquals("0", sheet.getRow(0).getCell(0).getStringCellValue());
+            assertEquals("149", sheet.getRow(149).getCell(0).getStringCellValue());
+            assertEquals(18 * 256, sheet.getColumnWidth(0));
+        }
+    }
+
+    @Test
+    void writesExistingJsonObjectWithScalarsAndCollections() throws Exception {
+        String definition = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<forma><sheet name=\"result\">"
+                + "<cell>#{title}</cell>"
+                + "<vertical-for item=\"item\" collection=\"items\" startRowIndex=\"1\" startColumnIndex=\"0\">"
+                + "<row><cell>#{item.value}</cell></row>"
+                + "</vertical-for></sheet></forma>";
+        JsonNode root = new JsonNode();
+        root.putVar("title", new JsonObject("report"));
+        root.putVar("items", new JsonObject(items(150)));
+        root.putVar("unused", new JsonObject(items(1)));
+
+        byte[] output = write(definition, new JsonObject(root));
+        try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(output))) {
+            Sheet sheet = workbook.getSheet("result");
+            assertEquals("report", sheet.getRow(0).getCell(0).getStringCellValue());
+            assertEquals("0", sheet.getRow(1).getCell(0).getStringCellValue());
+            assertEquals("149", sheet.getRow(150).getCell(0).getStringCellValue());
+        }
+    }
+
+    @Test
+    void rejectsNonObjectJsonObjectForJsonObjectOverload() {
+        String definition = "<?xml version=\"1.0\" encoding=\"utf-8\"?><forma/>";
+        assertThrows(IllegalArgumentException.class, () -> write(definition, new JsonObject("not-an-object")));
+    }
+
+    @Test
+    void appendsRootJsonArrayAfterTemplateRows() throws Exception {
+        String definition = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<forma><sheet name=\"result\">"
+                + "<cell>updated header</cell>"
+                + "<vertical-for item=\"item\" collection=\"list\" startRowIndex=\"1\" startColumnIndex=\"0\">"
+                + "<row><cell>#{item.value}</cell></row>"
+                + "</vertical-for></sheet></forma>";
+        String json = jsonValues(150);
+
+        byte[] output = writeTemplate(definition, template(), json);
+        try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(output))) {
+            Sheet sheet = workbook.getSheet("result");
+            assertEquals("updated header", sheet.getRow(0).getCell(0).getStringCellValue());
+            assertEquals("0", sheet.getRow(1).getCell(0).getStringCellValue());
+            assertEquals("149", sheet.getRow(150).getCell(0).getStringCellValue());
+        }
+    }
+
+    @Test
+    void createsNewSheetWhenWritingJsonObjectWithTemplate() throws Exception {
+        String definition = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<forma><sheet name=\"result\"><cell>#{title}</cell></sheet>"
+                + "<sheet name=\"appended\">"
+                + "<vertical-for item=\"item\" collection=\"items\" startRowIndex=\"0\" startColumnIndex=\"0\">"
+                + "<row><cell>#{item.value}</cell></row>"
+                + "</vertical-for></sheet></forma>";
+        JsonNode root = new JsonNode();
+        root.putVar("title", new JsonObject("updated header"));
+        root.putVar("items", new JsonObject(items(2)));
+
+        byte[] output = writeTemplate(definition, template(), new JsonObject(root));
+        try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(output))) {
+            assertEquals("updated header", workbook.getSheet("result").getRow(0).getCell(0).getStringCellValue());
+            assertEquals("0", workbook.getSheet("appended").getRow(0).getCell(0).getStringCellValue());
+            assertEquals("1", workbook.getSheet("appended").getRow(1).getCell(0).getStringCellValue());
+        }
+    }
+
+    @Test
+    void updatesExistingTemplateRowsAfterAppendCommands() throws Exception {
+        String definition = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<forma><sheet name=\"result\">"
+                + "<vertical-for item=\"item\" collection=\"list\" startRowIndex=\"1\" startColumnIndex=\"0\">"
+                + "<row><cell>#{item.value}</cell></row>"
+                + "</vertical-for><cell rowIndex=\"0\">replacement</cell>"
+                + "</sheet></forma>";
+        byte[] output = writeTemplate(
+                definition,
+                template(),
+                jsonValues(1)
+        );
+        try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(output))) {
+            Sheet sheet = workbook.getSheet("result");
+            assertEquals("replacement", sheet.getRow(0).getCell(0).getStringCellValue());
+            assertEquals("0", sheet.getRow(1).getCell(0).getStringCellValue());
+        }
+    }
+
+    @Test
+    void updatesTemplateRowsWithoutPromotingToStreaming() throws Exception {
+        String definition = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<forma><sheet name=\"result\"><cell>updated only</cell></sheet></forma>";
+
+        byte[] output = writeTemplate(definition, template(), new JsonObject(new JsonNode()));
+        try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(output))) {
+            assertEquals("updated only", workbook.getSheet("result").getRow(0).getCell(0).getStringCellValue());
+        }
+    }
+
+    private byte[] write(String definition, String json) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        new FormaStreamingWriter().write(
+                new ByteArrayInputStream(definition.getBytes(StandardCharsets.UTF_8)),
+                output,
+                new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))
+        );
+        return output.toByteArray();
+    }
+
+    private byte[] write(String definition, JsonObject jsonObject) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        new FormaStreamingWriter().write(
+                new ByteArrayInputStream(definition.getBytes(StandardCharsets.UTF_8)),
+                output,
+                jsonObject
+        );
+        return output.toByteArray();
+    }
+
+    private byte[] writeTemplate(String definition, byte[] template, String json) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        new FormaStreamingWriter().write(
+                new ByteArrayInputStream(definition.getBytes(StandardCharsets.UTF_8)),
+                output,
+                new ByteArrayInputStream(template),
+                new ByteArrayInputStream(json.getBytes(StandardCharsets.UTF_8))
+        );
+        return output.toByteArray();
+    }
+
+    private byte[] writeTemplate(String definition, byte[] template, JsonObject jsonObject) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        new FormaStreamingWriter().write(
+                new ByteArrayInputStream(definition.getBytes(StandardCharsets.UTF_8)),
+                output,
+                new ByteArrayInputStream(template),
+                jsonObject
+        );
+        return output.toByteArray();
+    }
+
+    private byte[] template() throws Exception {
+        try (Workbook workbook = new XSSFWorkbook(); ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            Sheet sheet = workbook.createSheet("result");
+            sheet.createRow(0).createCell(0).setCellValue("header");
+            workbook.write(output);
+            return output.toByteArray();
+        }
+    }
+
+    private JsonNodes items(int count) {
+        JsonNodes items = new JsonNodes();
+        for (int i = 0; i < count; i++) {
+            JsonNode item = new JsonNode();
+            item.putVar("value", new JsonObject(String.valueOf(i)));
+            items.add(item);
+        }
+        return items;
+    }
+
+    private String jsonValues(int count) {
+        StringBuilder json = new StringBuilder("[");
+        for (int i = 0; i < count; i++) {
+            if (i > 0) {
+                json.append(',');
+            }
+            json.append("{\"value\":\"").append(i).append("\"}");
+        }
+        return json.append(']').toString();
+    }
+}

--- a/src/test/java/io/luchta/forma4j/writer/stream/MappingSequenceSourceTest.java
+++ b/src/test/java/io/luchta/forma4j/writer/stream/MappingSequenceSourceTest.java
@@ -1,0 +1,154 @@
+package io.luchta.forma4j.writer.stream;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class MappingSequenceSourceTest {
+    @Test
+    void mapsElementsInOrder() throws Exception {
+        SequenceSource<String> source = source(
+                Arrays.asList("one", "two", "three"),
+                Replayability.REPLAYABLE
+        ).map(String::toUpperCase);
+
+        try (CloseableIterator<String> iterator = source.open()) {
+            assertEquals("ONE", iterator.next());
+            assertEquals("TWO", iterator.next());
+            assertEquals("THREE", iterator.next());
+            assertFalse(iterator.hasNext());
+        }
+    }
+
+    @Test
+    void mapsLazilyWhenNextIsCalled() throws Exception {
+        AtomicInteger mappingCount = new AtomicInteger();
+        SequenceSource<Integer> source = source(
+                Arrays.asList(1, 2),
+                Replayability.REPLAYABLE
+        ).map(value -> {
+            mappingCount.incrementAndGet();
+            return value * 10;
+        });
+
+        assertEquals(0, mappingCount.get());
+        try (CloseableIterator<Integer> iterator = source.open()) {
+            assertEquals(0, mappingCount.get());
+            assertTrue(iterator.hasNext());
+            assertEquals(0, mappingCount.get());
+
+            assertEquals(10, iterator.next());
+            assertEquals(1, mappingCount.get());
+            assertTrue(iterator.hasNext());
+            assertEquals(1, mappingCount.get());
+
+            assertEquals(20, iterator.next());
+            assertEquals(2, mappingCount.get());
+        }
+    }
+
+    @Test
+    void delegatesCloseToSourceIterator() throws Exception {
+        AtomicBoolean closed = new AtomicBoolean();
+        SequenceSource<Integer> source = new SequenceSource<Integer>() {
+            @Override
+            public CloseableIterator<Integer> open() {
+                Iterator<Integer> values = Arrays.asList(1, 2).iterator();
+                return new CloseableIterator<Integer>() {
+                    @Override
+                    public boolean hasNext() {
+                        return values.hasNext();
+                    }
+
+                    @Override
+                    public Integer next() {
+                        return values.next();
+                    }
+
+                    @Override
+                    public void close() {
+                        closed.set(true);
+                    }
+                };
+            }
+
+            @Override
+            public Replayability replayability() {
+                return Replayability.REPLAYABLE;
+            }
+        };
+
+        try (CloseableIterator<String> ignored = source.map(String::valueOf).open()) {
+            assertFalse(closed.get());
+        }
+
+        assertTrue(closed.get());
+    }
+
+    @ParameterizedTest
+    @EnumSource(Replayability.class)
+    void delegatesReplayability(Replayability replayability) {
+        SequenceSource<String> mapped = source(
+                java.util.Collections.<Integer>emptyList(),
+                replayability
+        ).map(String::valueOf);
+
+        assertSame(replayability, mapped.replayability());
+    }
+
+    @Test
+    void propagatesMapperExceptionUnchanged() throws Exception {
+        RuntimeException expected = new IllegalStateException("mapping failed");
+        SequenceSource<String> mapped = source(
+                java.util.Collections.singletonList(1),
+                Replayability.REPLAYABLE
+        ).map(value -> {
+            throw expected;
+        });
+
+        try (CloseableIterator<String> iterator = mapped.open()) {
+            RuntimeException actual = assertThrows(RuntimeException.class, iterator::next);
+            assertSame(expected, actual);
+        }
+    }
+
+    @Test
+    void rejectsNullMapper() {
+        SequenceSource<Integer> source = source(
+                java.util.Collections.singletonList(1),
+                Replayability.REPLAYABLE
+        );
+
+        assertThrows(NullPointerException.class, () -> source.map(null));
+    }
+
+    private <T> SequenceSource<T> source(
+            List<? extends T> values,
+            Replayability replayability
+    ) {
+        return new SequenceSource<T>() {
+            @Override
+            public CloseableIterator<T> open() throws IOException {
+                return CloseableIterators.from(values.iterator());
+            }
+
+            @Override
+            public Replayability replayability() {
+                return replayability;
+            }
+        };
+    }
+}

--- a/src/test/java/io/luchta/forma4j/writer/stream/NamedSequenceSourceTest.java
+++ b/src/test/java/io/luchta/forma4j/writer/stream/NamedSequenceSourceTest.java
@@ -1,0 +1,597 @@
+package io.luchta.forma4j.writer.stream;
+
+import io.luchta.forma4j.writer.Context;
+import io.luchta.forma4j.context.databind.json.JsonNode;
+import io.luchta.forma4j.context.databind.json.JsonNodes;
+import io.luchta.forma4j.context.databind.json.JsonObject;
+import io.luchta.forma4j.writer.definition.XmlDocument;
+import io.luchta.forma4j.writer.definition.XmlDocumentReader;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class NamedSequenceSourceTest {
+    @Test
+    void writesNamedSourcesScalarsAndDifferentSheets() throws Exception {
+        String definition = forma(
+                "<sheet name=\"headers\"><cell>#{title}</cell>"
+                        + vertical("header", "headers", 1, "#{header.value}")
+                        + "</sheet>"
+                        + "<sheet name=\"rows\">"
+                        + vertical("row", "rows", 0, "#{row.value}")
+                        + "</sheet>"
+        );
+        Context context = new Context();
+        context.putVar("title", "report");
+        context.putSequence(
+                "headers",
+                JsonArraySequenceSource.from(() -> bytes("[{\"value\":\"H1\"},{\"value\":\"H2\"}]"))
+        );
+        context.putSequence(
+                "rows",
+                IterableSequenceSource.replayable(Arrays.asList(row("R1"), row("R2"), row("R3")))
+        );
+
+        byte[] output = write(definition, context);
+        try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(output))) {
+            assertEquals("report", workbook.getSheet("headers").getRow(0).getCell(0).getStringCellValue());
+            assertEquals("H2", workbook.getSheet("headers").getRow(2).getCell(0).getStringCellValue());
+            assertEquals("R3", workbook.getSheet("rows").getRow(2).getCell(0).getStringCellValue());
+        }
+    }
+
+    @Test
+    void writesNamedContextSourcesIntoTemplate() throws Exception {
+        String definition = forma(
+                "<sheet name=\"result\"><cell>#{title}</cell>"
+                        + vertical("row", "rows", 1, "#{row.value}")
+                        + "</sheet>"
+        );
+        Context context = new Context();
+        context.putVar("title", "updated");
+        context.putVar("rows", Arrays.asList(row("one"), row("two")));
+
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        new FormaStreamingWriter().write(
+                bytes(definition),
+                output,
+                bytes(template()),
+                context
+        );
+
+        try (Workbook workbook = WorkbookFactory.create(
+                new ByteArrayInputStream(output.toByteArray()))) {
+            assertEquals("updated", workbook.getSheet("result").getRow(0).getCell(0).getStringCellValue());
+            assertEquals("two", workbook.getSheet("result").getRow(2).getCell(0).getStringCellValue());
+        }
+    }
+
+    @Test
+    void processesNestedJsonArrayWithoutRetainingRootRows() throws Exception {
+        String definition = forma(
+                "<sheet name=\"result\">"
+                        + "<vertical-for item=\"row\" collection=\"rows\" startRowIndex=\"0\" startColumnIndex=\"0\">"
+                        + "<row><cell>#{row.name}</cell>"
+                        + "<horizontal-for item=\"item\" collection=\"row.items\">"
+                        + "<cell>#{item}</cell>"
+                        + "</horizontal-for></row>"
+                        + "</vertical-for></sheet>"
+        );
+        Context context = new Context();
+        context.putSequence(
+                "rows",
+                JsonArraySequenceSource.from(() -> bytes(
+                        "[{\"name\":\"row1\",\"items\":[\"a\",\"b\"]},"
+                                + "{\"name\":\"row2\",\"items\":[\"c\",\"d\"]}]"
+                ))
+        );
+
+        byte[] output = write(definition, context);
+        try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(output))) {
+            Sheet sheet = workbook.getSheet("result");
+            assertEquals("row1", sheet.getRow(0).getCell(0).getStringCellValue());
+            assertEquals("b", sheet.getRow(0).getCell(2).getStringCellValue());
+            assertEquals("row2", sheet.getRow(1).getCell(0).getStringCellValue());
+            assertEquals("d", sheet.getRow(1).getCell(2).getStringCellValue());
+        }
+    }
+
+    @Test
+    void rejectsStaticOneShotMultipleReferencesBeforeWritingOutput() {
+        String definition = forma(
+                "<sheet name=\"first\">" + vertical("row", "rows", 0, "#{row.value}") + "</sheet>"
+                        + "<sheet name=\"second\">" + vertical("row", "rows", 0, "#{row.value}") + "</sheet>"
+        );
+        Context context = new Context();
+        context.putSequence(
+                "rows",
+                IterableSequenceSource.oneShot(Arrays.asList(row("value")).iterator())
+        );
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+
+        IllegalStateException failure = assertThrows(
+                IllegalStateException.class,
+                () -> new FormaStreamingWriter().write(bytes(definition), output, context)
+        );
+
+        assertEquals(
+                "collection 'rows' is one-shot but is referenced more than once",
+                failure.getMessage()
+        );
+        assertEquals(0, output.size());
+    }
+
+    @Test
+    void rejectsDynamicSecondOpenOfOneShotSource() {
+        String definition = forma(
+                "<sheet name=\"result\">"
+                        + "<vertical-for item=\"outerItem\" collection=\"outer\" startRowIndex=\"0\" startColumnIndex=\"0\">"
+                        + "<row><vertical-for item=\"row\" collection=\"rows\" startRowIndex=\"0\" startColumnIndex=\"0\">"
+                        + "<row><cell>#{row.value}</cell></row>"
+                        + "</vertical-for></row>"
+                        + "</vertical-for></sheet>"
+        );
+        Context context = new Context();
+        context.putVar("outer", Arrays.asList(row("first"), row("second")));
+        context.putSequence(
+                "rows",
+                IterableSequenceSource.oneShot(Arrays.asList(row("value")).iterator())
+        );
+
+        IllegalStateException failure = assertThrows(
+                IllegalStateException.class,
+                () -> write(definition, context)
+        );
+        assertEquals(
+                "collection 'rows' is one-shot but is referenced more than once",
+                failure.getMessage()
+        );
+    }
+
+    @Test
+    void reopensReplayableSourceAndReplaysSpooledOneShotSource() throws Exception {
+        String definition = forma(
+                "<sheet name=\"replay1\">" + vertical("row", "replay", 0, "#{row.value}") + "</sheet>"
+                        + "<sheet name=\"replay2\">" + vertical("row", "replay", 0, "#{row.value}") + "</sheet>"
+                        + "<sheet name=\"spool1\">" + vertical("row", "spool", 0, "#{row.value}") + "</sheet>"
+                        + "<sheet name=\"spool2\">" + vertical("row", "spool", 0, "#{row.value}") + "</sheet>"
+        );
+        Context context = new Context();
+        context.putSequence(
+                "replay",
+                IterableSequenceSource.replayable(Arrays.asList(row("R1"), row("R2")))
+        );
+        context.putSequence(
+                "spool",
+                SpooledSequenceSource.from(
+                        IterableSequenceSource.oneShot(
+                                Arrays.asList(row("S1"), row("S2")).iterator()
+                        )
+                )
+        );
+
+        byte[] output = write(definition, context);
+        try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(output))) {
+            assertEquals("R2", workbook.getSheet("replay1").getRow(1).getCell(0).getStringCellValue());
+            assertEquals("R2", workbook.getSheet("replay2").getRow(1).getCell(0).getStringCellValue());
+            assertEquals("S2", workbook.getSheet("spool1").getRow(1).getCell(0).getStringCellValue());
+            assertEquals("S2", workbook.getSheet("spool2").getRow(1).getCell(0).getStringCellValue());
+        }
+    }
+
+    @Test
+    void reportsSourceNameAndClosesIteratorAfterReadFailure() {
+        String definition = forma(
+                "<sheet name=\"result\">" + vertical("row", "employees", 0, "#{row.value}") + "</sheet>"
+        );
+        AtomicBoolean closed = new AtomicBoolean();
+        Context context = new Context();
+        context.putSequence("employees", failingSource(closed));
+
+        IOException failure = assertThrows(IOException.class, () -> write(definition, context));
+
+        assertEquals("failed to read collection 'employees'", failure.getMessage());
+        assertNotNull(failure.getCause());
+        assertTrue(closed.get());
+    }
+
+    @Test
+    void reportsSourceNameWhenOpenFails() {
+        String definition = forma(
+                "<sheet name=\"result\">" + vertical("row", "departments", 0, "#{row.value}") + "</sheet>"
+        );
+        Context context = new Context();
+        context.putSequence("departments", new SequenceSource<Object>() {
+            @Override
+            public CloseableIterator<Object> open() throws IOException {
+                throw new IOException("open failure");
+            }
+
+            @Override
+            public Replayability replayability() {
+                return Replayability.REPLAYABLE;
+            }
+        });
+
+        IOException failure = assertThrows(IOException.class, () -> write(definition, context));
+
+        assertEquals("failed to read collection 'departments'", failure.getMessage());
+        assertEquals("open failure", failure.getCause().getMessage());
+    }
+
+    @Test
+    void reportsSourceNameForMalformedJsonAndClosesItsStream() {
+        String definition = forma(
+                "<sheet name=\"result\">" + vertical("row", "employees", 0, "#{row.value}") + "</sheet>"
+        );
+        TrackingInputStream malformed = tracking("[{\"value\":\"broken\"");
+        Context context = new Context();
+        context.putSequence("employees", JsonArraySequenceSource.from(() -> malformed));
+
+        IOException failure = assertThrows(IOException.class, () -> write(definition, context));
+
+        assertEquals("failed to read collection 'employees'", failure.getMessage());
+        assertTrue(malformed.closed);
+    }
+
+    @Test
+    void reportsSourceNameWhenIteratorCloseFails() {
+        String definition = forma(
+                "<sheet name=\"result\">" + vertical("row", "rows", 0, "#{row.value}") + "</sheet>"
+        );
+        Context context = new Context();
+        context.putSequence("rows", closeFailingSource());
+
+        IOException failure = assertThrows(IOException.class, () -> write(definition, context));
+
+        assertEquals("failed to read collection 'rows'", failure.getMessage());
+        assertEquals("close failure", failure.getCause().getMessage());
+    }
+
+    @Test
+    void closesAutoCloseableIteratorFromDirectIterable() throws Exception {
+        String definition = forma(
+                "<sheet name=\"result\">" + vertical("row", "rows", 0, "#{row.value}") + "</sheet>"
+        );
+        AtomicBoolean closed = new AtomicBoolean();
+        Context context = new Context();
+        context.putVar("rows", closeTrackingIterable(closed));
+
+        write(definition, context);
+
+        assertTrue(closed.get());
+    }
+
+    @Test
+    void producesEquivalentCellsFromJsonObjectAndContext() throws Exception {
+        String definition = forma(
+                "<sheet name=\"result\"><cell>#{title}</cell>"
+                        + vertical("row", "rows", 1, "#{row.value}")
+                        + "</sheet>"
+        );
+        JsonNode root = new JsonNode();
+        root.putVar("title", new JsonObject("report"));
+        JsonNodes jsonRows = new JsonNodes();
+        jsonRows.add(jsonRow("one"));
+        jsonRows.add(jsonRow("two"));
+        root.putVar("rows", new JsonObject(jsonRows));
+
+        Context context = new Context();
+        context.putVar("title", "report");
+        context.putVar("rows", Arrays.asList(row("one"), row("two")));
+
+        ByteArrayOutputStream jsonOutput = new ByteArrayOutputStream();
+        new FormaStreamingWriter().write(
+                bytes(definition),
+                jsonOutput,
+                new JsonObject(root)
+        );
+        byte[] contextOutput = write(definition, context);
+
+        try (Workbook jsonWorkbook = WorkbookFactory.create(
+                new ByteArrayInputStream(jsonOutput.toByteArray()));
+             Workbook contextWorkbook = WorkbookFactory.create(
+                     new ByteArrayInputStream(contextOutput))) {
+            Sheet jsonSheet = jsonWorkbook.getSheet("result");
+            Sheet contextSheet = contextWorkbook.getSheet("result");
+            for (int row = 0; row <= 2; row++) {
+                assertEquals(
+                        jsonSheet.getRow(row).getCell(0).getCellType(),
+                        contextSheet.getRow(row).getCell(0).getCellType()
+                );
+                assertEquals(
+                        jsonSheet.getRow(row).getCell(0).getStringCellValue(),
+                        contextSheet.getRow(row).getCell(0).getStringCellValue()
+                );
+                assertEquals(
+                        jsonSheet.getRow(row).getCell(0).getCellStyle().getIndex(),
+                        contextSheet.getRow(row).getCell(0).getCellStyle().getIndex()
+                );
+            }
+        }
+    }
+
+    @Test
+    void leavesBorrowedStreamsOpenAndClosesSupplierStreams() throws Exception {
+        TrackingInputStream definition = tracking(forma(
+                "<sheet name=\"result\">" + vertical("row", "list", 0, "#{row.value}") + "</sheet>"
+        ));
+        TrackingInputStream borrowedJson = tracking("[{\"value\":\"ok\"}]");
+        TrackingOutputStream output = new TrackingOutputStream();
+
+        new FormaStreamingWriter().write(definition, output, borrowedJson);
+
+        assertFalse(definition.closed);
+        assertFalse(borrowedJson.closed);
+        assertFalse(output.closed);
+
+        TrackingInputStream suppliedJson = tracking("[{\"value\":\"ok\"}]");
+        Context context = new Context();
+        context.putSequence("rows", JsonArraySequenceSource.from(() -> suppliedJson));
+        write(
+                forma("<sheet name=\"result\">" + vertical("row", "rows", 0, "#{row.value}") + "</sheet>"),
+                context
+        );
+        assertTrue(suppliedJson.closed);
+
+        TrackingInputStream template = new TrackingInputStream(template());
+        Context templateContext = new Context();
+        templateContext.putVar("title", "updated");
+        new FormaStreamingWriter().write(
+                tracking(forma("<sheet name=\"result\"><cell>#{title}</cell></sheet>")),
+                new TrackingOutputStream(),
+                template,
+                templateContext
+        );
+        assertFalse(template.closed);
+    }
+
+    @Test
+    void deletesSpooledInputDirectoryWhenSessionCloses() throws Exception {
+        String definitionXml = forma(
+                "<sheet name=\"result\">" + vertical("row", "rows", 0, "#{row.value}") + "</sheet>"
+        );
+        XmlDocument definition = new XmlDocumentReader().read(bytes(definitionXml));
+        Context context = new Context();
+        context.putSequence(
+                "rows",
+                SpooledSequenceSource.from(
+                        IterableSequenceSource.oneShot(Arrays.asList(row("value")).iterator())
+                )
+        );
+
+        Path temporaryDirectory;
+        try (SequenceSourceSession session = new SequenceSourceSession(definition, context);
+             CloseableIterator<Object> iterator = session.open("rows", context.getVar("rows"))) {
+            assertTrue(iterator.hasNext());
+            temporaryDirectory = session.temporaryDirectoryForTesting();
+            assertNotNull(temporaryDirectory);
+            assertTrue(java.nio.file.Files.exists(temporaryDirectory));
+        }
+        assertFalse(java.nio.file.Files.exists(temporaryDirectory));
+    }
+
+    @Test
+    void deletesSpooledInputDirectoryAfterSpoolingFailure() throws Exception {
+        String definitionXml = forma(
+                "<sheet name=\"result\">" + vertical("row", "rows", 0, "#{row.value}") + "</sheet>"
+        );
+        XmlDocument definition = new XmlDocumentReader().read(bytes(definitionXml));
+        Context context = new Context();
+        context.putSequence(
+                "rows",
+                SpooledSequenceSource.from(
+                        IterableSequenceSource.oneShot(
+                                Arrays.<Object>asList(new Object()).iterator()
+                        )
+                )
+        );
+
+        Path temporaryDirectory;
+        try (SequenceSourceSession session = new SequenceSourceSession(definition, context)) {
+            UncheckedIOException failure = assertThrows(
+                    UncheckedIOException.class,
+                    () -> session.open("rows", context.getVar("rows"))
+            );
+            assertEquals("failed to read collection 'rows'", failure.getCause().getMessage());
+            temporaryDirectory = session.temporaryDirectoryForTesting();
+            assertTrue(java.nio.file.Files.exists(temporaryDirectory));
+        }
+        assertFalse(java.nio.file.Files.exists(temporaryDirectory));
+    }
+
+    private SequenceSource<Object> failingSource(AtomicBoolean closed) {
+        return new SequenceSource<Object>() {
+            @Override
+            public CloseableIterator<Object> open() {
+                return new CloseableIterator<Object>() {
+                    @Override
+                    public boolean hasNext() {
+                        return true;
+                    }
+
+                    @Override
+                    public Object next() {
+                        throw new UncheckedIOException(new IOException("source failure"));
+                    }
+
+                    @Override
+                    public void close() {
+                        closed.set(true);
+                    }
+                };
+            }
+
+            @Override
+            public Replayability replayability() {
+                return Replayability.REPLAYABLE;
+            }
+        };
+    }
+
+    private SequenceSource<Object> closeFailingSource() {
+        return new SequenceSource<Object>() {
+            @Override
+            public CloseableIterator<Object> open() {
+                Iterator<Object> values = Arrays.<Object>asList(row("value")).iterator();
+                return new CloseableIterator<Object>() {
+                    @Override
+                    public boolean hasNext() {
+                        return values.hasNext();
+                    }
+
+                    @Override
+                    public Object next() {
+                        return values.next();
+                    }
+
+                    @Override
+                    public void close() throws IOException {
+                        throw new IOException("close failure");
+                    }
+                };
+            }
+
+            @Override
+            public Replayability replayability() {
+                return Replayability.REPLAYABLE;
+            }
+        };
+    }
+
+    private Iterable<Object> closeTrackingIterable(AtomicBoolean closed) {
+        return () -> new CloseTrackingIterator(
+                Arrays.<Object>asList(row("value")).iterator(),
+                closed
+        );
+    }
+
+    private byte[] write(String definition, Context context) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        new FormaStreamingWriter().write(bytes(definition), output, context);
+        return output.toByteArray();
+    }
+
+    private String forma(String sheets) {
+        return "<?xml version=\"1.0\" encoding=\"utf-8\"?><forma>" + sheets + "</forma>";
+    }
+
+    private String vertical(
+            String item,
+            String collection,
+            int startRow,
+            String cell
+    ) {
+        return "<vertical-for item=\"" + item + "\" collection=\"" + collection
+                + "\" startRowIndex=\"" + startRow + "\" startColumnIndex=\"0\">"
+                + "<row><cell>" + cell + "</cell></row>"
+                + "</vertical-for>";
+    }
+
+    private Map<String, Object> row(String value) {
+        Map<String, Object> row = new LinkedHashMap<>();
+        row.put("value", value);
+        return row;
+    }
+
+    private JsonNode jsonRow(String value) {
+        JsonNode row = new JsonNode();
+        row.putVar("value", new JsonObject(value));
+        return row;
+    }
+
+    private InputStream bytes(String value) {
+        return new ByteArrayInputStream(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private InputStream bytes(byte[] value) {
+        return new ByteArrayInputStream(value);
+    }
+
+    private byte[] template() throws Exception {
+        try (Workbook workbook = new XSSFWorkbook();
+             ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            workbook.createSheet("result").createRow(0).createCell(0).setCellValue("old");
+            workbook.write(output);
+            return output.toByteArray();
+        }
+    }
+
+    private TrackingInputStream tracking(String value) {
+        return new TrackingInputStream(value.getBytes(StandardCharsets.UTF_8));
+    }
+
+    private static final class TrackingInputStream extends ByteArrayInputStream {
+        private boolean closed;
+
+        private TrackingInputStream(byte[] value) {
+            super(value);
+        }
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+    }
+
+    private static final class TrackingOutputStream extends ByteArrayOutputStream {
+        private boolean closed;
+
+        @Override
+        public void close() throws IOException {
+            closed = true;
+            super.close();
+        }
+    }
+
+    private static final class CloseTrackingIterator
+            implements Iterator<Object>, AutoCloseable {
+        private final Iterator<Object> delegate;
+        private final AtomicBoolean closed;
+
+        private CloseTrackingIterator(
+                Iterator<Object> delegate,
+                AtomicBoolean closed
+        ) {
+            this.delegate = delegate;
+            this.closed = closed;
+        }
+
+        @Override
+        public boolean hasNext() {
+            return delegate.hasNext();
+        }
+
+        @Override
+        public Object next() {
+            return delegate.next();
+        }
+
+        @Override
+        public void close() {
+            closed.set(true);
+        }
+    }
+}

--- a/src/test/java/io/luchta/forma4j/writer/stream/OoxmlStreamingFeaturesTest.java
+++ b/src/test/java/io/luchta/forma4j/writer/stream/OoxmlStreamingFeaturesTest.java
@@ -1,0 +1,274 @@
+package io.luchta.forma4j.writer.stream;
+
+import io.luchta.forma4j.context.databind.json.JsonNode;
+import io.luchta.forma4j.context.databind.json.JsonObject;
+import org.apache.poi.ss.usermodel.BorderStyle;
+import org.apache.poi.ss.usermodel.Cell;
+import org.apache.poi.ss.usermodel.CellType;
+import org.apache.poi.ss.usermodel.ClientAnchor;
+import org.apache.poi.ss.usermodel.CreationHelper;
+import org.apache.poi.ss.usermodel.Drawing;
+import org.apache.poi.ss.usermodel.FillPatternType;
+import org.apache.poi.ss.usermodel.IndexedColors;
+import org.apache.poi.ss.usermodel.Picture;
+import org.apache.poi.ss.usermodel.Sheet;
+import org.apache.poi.ss.usermodel.Workbook;
+import org.apache.poi.ss.usermodel.WorkbookFactory;
+import org.apache.poi.xssf.usermodel.XSSFSheet;
+import org.apache.poi.xssf.usermodel.XSSFWorkbook;
+import org.junit.jupiter.api.Test;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipInputStream;
+import java.util.zip.ZipOutputStream;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OoxmlStreamingFeaturesTest {
+    @Test
+    void writesTypesStylesWidthsFiltersFormulasAndMultipleSheets() throws Exception {
+        String definition = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<forma><sheet name=\"typed\">"
+                + "<row rowIndex=\"0\" startColumnIndex=\"0\" autoFilter=\"true\">"
+                + "<cell style=\"border:thin;background-color:#FFC000;width:18\">header</cell>"
+                + "<cell>value</cell></row>"
+                + "<row rowIndex=\"1\" startColumnIndex=\"0\">"
+                + "<cell cellType=\"boolean\">#{bool}</cell>"
+                + "<cell cellType=\"numeric\">#{number}</cell>"
+                + "<cell cellType=\"date\">#{date}</cell>"
+                + "<cell cellType=\"datetime\">#{datetime}</cell>"
+                + "<cell cellType=\"formula\">#{formula}</cell>"
+                + "</row></sheet>"
+                + "<sheet name=\"other\"><cell>second sheet</cell></sheet></forma>";
+
+        JsonNode root = new JsonNode();
+        root.putVar("bool", new JsonObject(true));
+        root.putVar("number", new JsonObject(new BigDecimal("12.5")));
+        root.putVar("date", new JsonObject(LocalDate.of(2026, 7, 23)));
+        root.putVar("datetime", new JsonObject(LocalDateTime.of(2026, 7, 23, 12, 34, 56)));
+        root.putVar("formula", new JsonObject("1+1"));
+
+        byte[] output = write(definition, new JsonObject(root));
+        try (XSSFWorkbook workbook = new XSSFWorkbook(new ByteArrayInputStream(output))) {
+            Sheet sheet = workbook.getSheet("typed");
+            assertEquals(CellType.BOOLEAN, sheet.getRow(1).getCell(0).getCellType());
+            assertTrue(sheet.getRow(1).getCell(0).getBooleanCellValue());
+            assertEquals(12.5d, sheet.getRow(1).getCell(1).getNumericCellValue());
+            assertEquals(
+                    LocalDate.of(2026, 7, 23),
+                    sheet.getRow(1).getCell(2).getLocalDateTimeCellValue().toLocalDate()
+            );
+            assertEquals(
+                    LocalDateTime.of(2026, 7, 23, 12, 34, 56),
+                    sheet.getRow(1).getCell(3).getLocalDateTimeCellValue()
+            );
+            assertEquals("1+1", sheet.getRow(1).getCell(4).getCellFormula());
+            assertEquals(
+                    BorderStyle.THIN,
+                    sheet.getRow(0).getCell(0).getCellStyle().getBorderBottom()
+            );
+            assertEquals(
+                    FillPatternType.SOLID_FOREGROUND,
+                    sheet.getRow(0).getCell(0).getCellStyle().getFillPattern()
+            );
+            assertEquals(18 * 256, sheet.getColumnWidth(0));
+            assertEquals(
+                    "A1:B1",
+                    ((XSSFSheet) sheet).getCTWorksheet().getAutoFilter().getRef()
+            );
+            assertEquals(
+                    "second sheet",
+                    workbook.getSheet("other").getRow(0).getCell(0).getStringCellValue()
+            );
+            assertTrue(workbook.getForceFormulaRecalculation());
+        }
+    }
+
+    @Test
+    void preservesUnknownTemplatePartsAndExistingStylesWhileAddingStyles() throws Exception {
+        byte[] template = styledTemplate();
+        byte[] marker = zipEntries(template).get("docProps/app.xml");
+        byte[] image = zipEntries(template).get("xl/media/image1.png");
+        assertNotNull(marker);
+        assertNotNull(image);
+        String definition = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<forma><sheet name=\"result\">"
+                + "<cell>updated</cell>"
+                + "<cell rowIndex=\"1\" style=\"border:thin;width:22\">appended</cell>"
+                + "<cell rowIndex=\"2\" cellType=\"formula\">1+1</cell>"
+                + "</sheet></forma>";
+
+        byte[] output = writeTemplate(definition, template, new JsonObject(new JsonNode()));
+        assertArrayEquals(marker, zipEntries(output).get("docProps/app.xml"));
+        assertArrayEquals(image, zipEntries(output).get("xl/media/image1.png"));
+        try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(output))) {
+            Sheet sheet = workbook.getSheet("result");
+            Cell updated = sheet.getRow(0).getCell(0);
+            assertEquals("updated", updated.getStringCellValue());
+            assertEquals(IndexedColors.YELLOW.getIndex(), updated.getCellStyle().getFillForegroundColor());
+            assertEquals(
+                    BorderStyle.THIN,
+                    sheet.getRow(1).getCell(0).getCellStyle().getBorderBottom()
+            );
+            assertEquals(22 * 256, sheet.getColumnWidth(0));
+            assertEquals(1, workbook.getAllPictures().size());
+            assertEquals("1+1", sheet.getRow(2).getCell(0).getCellFormula());
+            assertTrue(workbook.getForceFormulaRecalculation());
+        }
+    }
+
+    @Test
+    void usesThe1904DateWindowingFromTemplate() throws Exception {
+        byte[] template;
+        try (XSSFWorkbook workbook = new XSSFWorkbook();
+             ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            workbook.createSheet("result");
+            if (!workbook.getCTWorkbook().isSetWorkbookPr()) {
+                workbook.getCTWorkbook().addNewWorkbookPr();
+            }
+            workbook.getCTWorkbook().getWorkbookPr().setDate1904(true);
+            workbook.write(output);
+            template = output.toByteArray();
+        }
+
+        String definition = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<forma><sheet name=\"result\">"
+                + "<cell cellType=\"date\">#{date}</cell>"
+                + "</sheet></forma>";
+        JsonNode root = new JsonNode();
+        root.putVar("date", new JsonObject(LocalDate.of(2026, 7, 23)));
+
+        byte[] output = writeTemplate(definition, template, new JsonObject(root));
+        try (Workbook workbook = WorkbookFactory.create(new ByteArrayInputStream(output))) {
+            assertEquals(
+                    LocalDate.of(2026, 7, 23),
+                    workbook.getSheet("result")
+                            .getRow(0)
+                            .getCell(0)
+                            .getLocalDateTimeCellValue()
+                            .toLocalDate()
+            );
+        }
+    }
+
+    @Test
+    void rejectsDigitallySignedTemplatePackages() throws Exception {
+        byte[] signed = addEntry(
+                styledTemplate(),
+                "_xmlsignatures/sig1.xml",
+                "<signature/>".getBytes(StandardCharsets.UTF_8)
+        );
+        String definition = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<forma><sheet name=\"result\"><cell>value</cell></sheet></forma>";
+
+        assertThrows(
+                IllegalArgumentException.class,
+                () -> writeTemplate(definition, signed, new JsonObject(new JsonNode()))
+        );
+    }
+
+    private byte[] write(String definition, JsonObject jsonObject) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        new FormaStreamingWriter().write(
+                new ByteArrayInputStream(definition.getBytes(StandardCharsets.UTF_8)),
+                output,
+                jsonObject
+        );
+        return output.toByteArray();
+    }
+
+    private byte[] writeTemplate(
+            String definition,
+            byte[] template,
+            JsonObject jsonObject
+    ) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        new FormaStreamingWriter().write(
+                new ByteArrayInputStream(definition.getBytes(StandardCharsets.UTF_8)),
+                output,
+                new ByteArrayInputStream(template),
+                jsonObject
+        );
+        return output.toByteArray();
+    }
+
+    private byte[] styledTemplate() throws Exception {
+        try (XSSFWorkbook workbook = new XSSFWorkbook();
+             ByteArrayOutputStream output = new ByteArrayOutputStream()) {
+            Sheet sheet = workbook.createSheet("result");
+            Cell cell = sheet.createRow(0).createCell(0);
+            cell.setCellValue("original");
+            org.apache.poi.ss.usermodel.CellStyle style = workbook.createCellStyle();
+            style.setFillForegroundColor(IndexedColors.YELLOW.getIndex());
+            style.setFillPattern(FillPatternType.SOLID_FOREGROUND);
+            cell.setCellStyle(style);
+            sheet.setColumnWidth(0, 10 * 256);
+
+            byte[] png = Base64.getDecoder().decode(
+                    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwC"
+                            + "AAAAC0lEQVR42mNk+A8AAQUBAScY42YAAAAASUVORK5CYII="
+            );
+            int pictureIndex = workbook.addPicture(png, Workbook.PICTURE_TYPE_PNG);
+            CreationHelper helper = workbook.getCreationHelper();
+            Drawing<?> drawing = sheet.createDrawingPatriarch();
+            ClientAnchor anchor = helper.createClientAnchor();
+            anchor.setCol1(2);
+            anchor.setRow1(0);
+            Picture picture = drawing.createPicture(anchor, pictureIndex);
+            picture.resize();
+            workbook.write(output);
+            return output.toByteArray();
+        }
+    }
+
+    private byte[] addEntry(byte[] source, String name, byte[] value) throws Exception {
+        ByteArrayOutputStream output = new ByteArrayOutputStream();
+        try (ZipInputStream input = new ZipInputStream(new ByteArrayInputStream(source));
+             ZipOutputStream zip = new ZipOutputStream(output)) {
+            ZipEntry entry;
+            byte[] buffer = new byte[8192];
+            while ((entry = input.getNextEntry()) != null) {
+                zip.putNextEntry(new ZipEntry(entry.getName()));
+                int length;
+                while ((length = input.read(buffer)) >= 0) {
+                    zip.write(buffer, 0, length);
+                }
+                zip.closeEntry();
+            }
+            zip.putNextEntry(new ZipEntry(name));
+            zip.write(value);
+            zip.closeEntry();
+        }
+        return output.toByteArray();
+    }
+
+    private Map<String, byte[]> zipEntries(byte[] xlsx) throws Exception {
+        Map<String, byte[]> entries = new HashMap<>();
+        try (ZipInputStream input = new ZipInputStream(new ByteArrayInputStream(xlsx))) {
+            ZipEntry entry;
+            byte[] buffer = new byte[8192];
+            while ((entry = input.getNextEntry()) != null) {
+                ByteArrayOutputStream output = new ByteArrayOutputStream();
+                int length;
+                while ((length = input.read(buffer)) >= 0) {
+                    output.write(buffer, 0, length);
+                }
+                entries.put(entry.getName(), output.toByteArray());
+            }
+        }
+        return entries;
+    }
+}

--- a/src/test/java/io/luchta/forma4j/writer/stream/StreamingInputLowHeapTest.java
+++ b/src/test/java/io/luchta/forma4j/writer/stream/StreamingInputLowHeapTest.java
@@ -1,0 +1,79 @@
+package io.luchta.forma4j.writer.stream;
+
+import io.luchta.forma4j.writer.Context;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.io.ByteArrayInputStream;
+import java.io.OutputStream;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.AbstractList;
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+@Tag("low-heap")
+class StreamingInputLowHeapTest {
+    private static final int ROW_COUNT = 10_000;
+    private static final int COLUMN_COUNT = 100;
+
+    @Test
+    void writesOneMillionCellsFromLazyRowsWith256MiBHeap(@TempDir Path directory)
+            throws Exception {
+        String definition = "<?xml version=\"1.0\" encoding=\"utf-8\"?>"
+                + "<forma><sheet name=\"result\">"
+                + "<vertical-for item=\"row\" collection=\"rows\" "
+                + "startRowIndex=\"0\" startColumnIndex=\"0\">"
+                + "<row><horizontal-for item=\"item\" collection=\"row.items\">"
+                + "<cell>#{item}</cell>"
+                + "</horizontal-for></row>"
+                + "</vertical-for></sheet></forma>";
+        Context context = new Context();
+        context.putVar("rows", lazyRows());
+        Path outputFile = directory.resolve("million-cells.xlsx");
+
+        try (OutputStream output = Files.newOutputStream(outputFile)) {
+            new FormaStreamingWriter().write(
+                    new ByteArrayInputStream(definition.getBytes(StandardCharsets.UTF_8)),
+                    output,
+                    context
+            );
+        }
+
+        assertTrue(Files.size(outputFile) > 0);
+    }
+
+    private Iterable<Map<String, Object>> lazyRows() {
+        return () -> new Iterator<Map<String, Object>>() {
+            private int row;
+
+            @Override
+            public boolean hasNext() {
+                return row < ROW_COUNT;
+            }
+
+            @Override
+            public Map<String, Object> next() {
+                int current = row++;
+                Map<String, Object> value = new LinkedHashMap<>();
+                value.put("items", new AbstractList<String>() {
+                    @Override
+                    public String get(int column) {
+                        return current + "-" + column;
+                    }
+
+                    @Override
+                    public int size() {
+                        return COLUMN_COUNT;
+                    }
+                });
+                return value;
+            }
+        };
+    }
+}


### PR DESCRIPTION
## 概要

Excel出力を低メモリで行う `FormaStreamingWriter` を追加。大量データを逐次処理し、セル情報を一時ファイルへ退避しながらOOXML形式のXLSXを生成。

## 変更内容

- `FormaStreamingWriter` とストリーミング用データソースAPIを追加
  - `Context#putSequence` で名前付きのストリーミングコレクションを登録可能に
  - `Iterable`、JSON配列InputStream、変換済みソース、スプール済みソースをサポート
  - one-shotなデータソースの複数参照を検出し、明示的にエラー化
- 出力処理を戦略化し、従来の蓄積方式とストリーミング方式を分離
- OOXMLを直接生成する出力処理を追加
  - 複数シート、セル型、数式、スタイル、列幅、オートフィルターに対応
  - テンプレート出力時は未変更のOOXMLパーツ・既存スタイル・画像を保持
  - 1904日付システムを考慮
- `vertical-for` / `horizontal-for` / `list` を逐次イテレーションに対応
- ストリーミング利用方法をドキュメントへ追記
- バージョンを `1.10.0-SNAPSHOT` へ更新

## 制約

- `autoSizeColumn` はストリーミング出力では利用できません。
- テンプレートは非暗号化の `.xlsx` のみ対象です。マクロまたは電子署名を含むファイルは受け付けません。

## テスト

- ストリーミング出力・テンプレート保持・データソースの再利用性・リソースクローズを検証するテストを追加
- 256 MiBヒープで100万セルを出力する低メモリテストを追加（`./gradlew lowHeapTest`）