### PR TITLE
aws s3 への publish フローを追加

### DIFF
--- a/.github/workflows/publish-snapshot.yml
+++ b/.github/workflows/publish-snapshot.yml
@@ -1,0 +1,36 @@
+name: Publish Snapshot Library
+
+on:
+  # 誤クリック防止のための入力
+  workflow_dispatch:
+    inputs:
+      name:
+        description: 'Publish Snapshot Library'
+        required: true
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-java@v5
+        with:
+          java-version: '11'
+          distribution: corretto
+
+      - name: Publish package
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+        run: ./gradlew clean build publishShadowPublicationToForma4jS3Repository -PpublishTarget=s3 --stacktrace
+
+      - name: Notify build finish
+        uses: 8398a7/action-slack@v3
+        with:
+          status: ${{ job.status }}
+          author_name: Publish Result
+          fields: ref,job
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
+        if: always()

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 
 - [はじめに](docs/README.md)
 - [Gradle](docs/gradle/gradle.md)
+- [Maven](docs/maven/maven.md)
 - Writer
   - [XML](docs/writer/xml.md)
   - [formaタグ](docs/writer/forma.md)

--- a/build.gradle
+++ b/build.gradle
@@ -112,8 +112,20 @@ publishing {
             name = 'localStaging'
             url  = layout.buildDirectory.dir('staging-deploy')
         }
+
+        maven {
+            name = 'forma4jS3'
+            url  = 's3://mars-repository-hosting.s3.ap-northeast-1.amazonaws.com/snapshot'
+            credentials(AwsCredentials) {
+                accessKey = System.getenv('AWS_ACCESS_KEY_ID')
+                secretKey = System.getenv('AWS_SECRET_ACCESS_KEY')
+            }
+        }
     }
 }
+
+def publishTarget = project.findProperty('publishTarget') ?: 'central'
+def isS3Only = (publishTarget == 's3')
 
 jreleaser {
     project {
@@ -131,7 +143,7 @@ jreleaser {
         maven {
             mavenCentral {
                 sonatype {
-                    active = 'ALWAYS'
+                    active = isS3Only ? 'NEVER' : 'ALWAYS'
                     url = 'https://central.sonatype.com/api/v1/publisher'
                     stagingRepository("${layout.buildDirectory.get().asFile}/staging-deploy")
                 }

--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -2,6 +2,7 @@
 
 - [はじめに](README.md)
 - [Gradle](gradle/gradle.md)
+- [Maven](maven/maven.md)
 - Writer
   - [XML](writer/xml.md)
   - [formaタグ](writer/forma.md)

--- a/docs/maven/maven.md
+++ b/docs/maven/maven.md
@@ -1,0 +1,13 @@
+# Maven
+
+forma4jをMavenと組み合わせる方法について説明します。
+
+正式リリースは[Maven Central](https://central.sonatype.com/artifact/io.luchta/forma4j)から取得できます。
+
+```xml
+<dependency>
+  <groupId>io.luchta</groupId>
+  <artifactId>forma4j</artifactId>
+  <version>1.10.0</version>
+</dependency>
+```


### PR DESCRIPTION
## 概要

forma4jのSNAPSHOT版をS3へ公開できるよう、公開設定と手動実行用のGitHub Actionsワークフローを追加しました。また、Mavenでの利用方法をドキュメント化しました。

## 変更内容

- S3 Mavenリポジトリ（`snapshot`）への公開設定を追加
- `publishTarget=s3` 指定時にMaven Centralへの公開を無効化
- SNAPSHOTライブラリを公開する手動GitHub Actionsワークフローを追加
  - AWS認証情報をSecretsから取得
  - 実行結果をSlackへ通知
- Mavenの依存関係追加手順を追加し、README・ドキュメント目次から参照可能に変更
