### PR TITLE
スナップショット公開時の JAR 出力競合を解消

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 
     implementation "jakarta.xml.bind:jakarta.xml.bind-api:4.0.2"
     implementation "com.sun.xml.bind:jaxb-impl:4.0.6"
-    
+
     implementation group: 'com.fasterxml.jackson.core', name: 'jackson-core', version: '2.20.0'
     implementation group: 'com.fasterxml.jackson.datatype', name: 'jackson-datatype-jsr310', version: '2.20.0'
 
@@ -152,13 +152,16 @@ jreleaser {
     }
 }
 
+tasks.named("jar") {
+    archiveClassifier.set("plain")
+}
+
 shadowJar {
     archiveClassifier.set("")
     mergeServiceFiles()
 }
 
 tasks.named("publishShadowPublicationToLocalStagingRepository") {
-    dependsOn("jar")
     dependsOn("shadowJar", "sourcesJar", "javadocJar")
 }
 


### PR DESCRIPTION
通常 JAR と Shadow JAR の出力パス重複を解消し、S3 スナップショット公開でも Gradle の暗黙依存チェックに失敗しないように修正。