### PR TITLE
CIで低ヒープのStreaming Writerテストを実行

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -36,8 +36,31 @@ jobs:
           name: junit-results-${{ matrix.java-version }}
           path: build/reports/tests/test
 
+    low-heap-test:
+      runs-on: ubuntu-latest
+
+      steps:
+      - uses: actions/checkout@v6
+      - name: Set up JDK
+        uses: actions/setup-java@v5
+        with:
+          java-version: 11
+          distribution: 'corretto'
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Run low-heap tests
+        run: ./gradlew lowHeapTest --stacktrace
+      - name: Upload low-heap JUnit test results
+        uses: actions/upload-artifact@v7
+        if: failure()
+        with:
+          name: low-heap-junit-results-java-11
+          path: |
+            build/reports/tests/lowHeapTest
+            build/test-results/lowHeapTest
+
     notification:
-      needs: [ test ]
+      needs: [ test, low-heap-test ]
 
       runs-on: ubuntu-latest
 


### PR DESCRIPTION
## 概要

GitHub Actionsに、256 MiBヒープでStreaming Writerの低メモリテストを実行するジョブを追加。

## 変更内容

- `low-heap-test` ジョブを追加
- Java 11で `./gradlew lowHeapTest --stacktrace` を実行
- 失敗時に低ヒープテストのHTMLレポートとJUnit XMLを成果物としてアップロード
- 通知ジョブが通常テストと低ヒープテストの両方を待機するよう変更

## 確認

- `./gradlew lowHeapTest --rerun-tasks --stacktrace` が成功
- HTMLレポートおよびJUnit XMLの出力を確認済み